### PR TITLE
Emote menu semi-rewrite

### DIFF
--- a/src/builtins/emotes/category.jsx
+++ b/src/builtins/emotes/category.jsx
@@ -10,14 +10,14 @@ export default class Category extends React.Component {
     }
     render() {
         return <div className="bd-emote-category">
-            <div className="bd-emote-content">
-                <div className="bd-emote-header" onClick={() => this.setState({opened: !this.state.opened})}>
-                    <div className="bd-emote-headerIcon">
+            <div className={`bd-emote-header ${this.state.opened ? "bd-open" : "bd-closed"}`}>
+                <div className="bd-emote-header-inner" onClick={() => this.setState({opened: !this.state.opened})}>
+                    <div className="bd-emote-header-icon">
                         {this.props.icon ? this.props.icon : null}
                     </div>
-                    <div className="bd-emote-headerLabel">{this.props.label}</div>
-                    <div className="bd-emote-headerCollapseIcon">
-                        <DownArrow className={this.state.opened ? "bd-emote-opened" : "bd-emote-closed"}/>
+                    <div className="bd-emote-header-label">{this.props.label}</div>
+                    <div className={`bd-emote-collapse-icon ${this.state.opened ? "bd-open" : "bd-closed"}`}>
+                        <DownArrow/>
                     </div>
                 </div>
             </div>

--- a/src/modules/componentpatcher.js
+++ b/src/modules/componentpatcher.js
@@ -58,7 +58,8 @@ export default new class ComponentPatcher {
         });
     }
     
-    /*patchGuildListItems() {
+    /*
+    patchGuildListItems() {
         if (this.guildListItemsPatch) return;
         const listItemClass = DiscordModules.GuildClasses.listItem.split(" ")[0];
         const blobClass = DiscordModules.GuildClasses.blobContainer.split(" ")[0];
@@ -107,7 +108,8 @@ export default new class ComponentPatcher {
             if (!Separator) return;
             Separator.type = GuildSeparator;
         });
-    }*/
+    }
+    */
 
     patchMessageHeader() {
         if (this.messageHeaderPatch) return;

--- a/src/modules/componentpatcher.js
+++ b/src/modules/componentpatcher.js
@@ -57,8 +57,8 @@ export default new class ComponentPatcher {
             };
         });
     }
-
-    patchGuildListItems() {
+    
+    /*patchGuildListItems() {
         if (this.guildListItemsPatch) return;
         const listItemClass = DiscordModules.GuildClasses.listItem.split(" ")[0];
         const blobClass = DiscordModules.GuildClasses.blobContainer.split(" ")[0];
@@ -107,7 +107,7 @@ export default new class ComponentPatcher {
             if (!Separator) return;
             Separator.type = GuildSeparator;
         });
-    }
+    }*/
 
     patchMessageHeader() {
         if (this.messageHeaderPatch) return;
@@ -156,18 +156,19 @@ export default new class ComponentPatcher {
 // Tropical's notes
 
 /* 
-html [maximized | bd]
+html [maximized | bd | stable | canary | ptb]
 .iconWrapper-2OrFZ1 [type]
 .sidebar-2K8pFh [guild-id]
-.wrapper-2jXpOf [voice | text | announcement | store | private | nsfw]
-.chat-3bRxxu [channnel | guild-id]
+.wrapper-2jXpOf [voice | text | announcement | store | private | nsfw | rules]
+.chat-3bRxxu [channnel-name | guild-id]
 .listItem-2P_4kh [type | state]
 .privateChannels-1nO12o [library-hidden]
 .member-3-YXUe [user-id]
-.message-2qnXI6 [type | author-id | group-end]
+.message-2qnXI6 [type | author-id | group-end | message-content]
 .wrapper-3t9DeA [user-id | status]
-.userPopout-3XzG_A [state | user-id]
-.root-SR8cQa [state | user-id]
+.userPopout-3XzG_A [user-id]
+.root-SR8cQa [user-id]
 .contentRegion-3nDuYy [settings-page]
 .item-PXvHYJ [settings-page]
+.wrapper-35wsBm [valid | expired | joined]
 */

--- a/src/modules/componentpatcher.js
+++ b/src/modules/componentpatcher.js
@@ -12,9 +12,11 @@ export default new class ComponentPatcher {
 
     initialize() {
         Utilities.suppressErrors(this.patchSocial.bind(this), "BD Social Patch")();
+        /*
         Utilities.suppressErrors(this.patchGuildPills.bind(this), "BD Guild Pills Patch")();
         Utilities.suppressErrors(this.patchGuildListItems.bind(this), "BD Guild List Items Patch")();
         Utilities.suppressErrors(this.patchGuildSeparator.bind(this), "BD Guild Separator Patch")();
+        */
         Utilities.suppressErrors(this.patchMessageHeader.bind(this), "BD Message Header Patch")();
         Utilities.suppressErrors(this.patchMemberList.bind(this), "BD Member List Patch")();
     }
@@ -108,8 +110,7 @@ export default new class ComponentPatcher {
             if (!Separator) return;
             Separator.type = GuildSeparator;
         });
-    }
-    */
+    }*/
 
     patchMessageHeader() {
         if (this.messageHeaderPatch) return;

--- a/src/styles/builtins/emotemenu.css
+++ b/src/styles/builtins/emotemenu.css
@@ -1,132 +1,82 @@
-#removemenu {
-    width: auto;
-    background: #505050;
-    z-index: 999999;
-    box-shadow: 0 0 2px #000;
-    padding: 2px;
-    left: 25px;
-    display: block;
-    cursor: pointer;
-    color: #fff;
-    position: fixed;
-}
-
-#removemenu ul a {
-    text-decoration: none;
-    color: #fff;
-    padding: 3px;
-}
-
-.emotewrapper {
-    position: relative;
-    display: inline-flex;
-    object-fit: contain;
-    margin: -0.1em 0.05em -0.2em 0.1em;
-    vertical-align: top;
-}
-
-.emotewrapper.jumboable {
-    margin-bottom: 0;
-    margin-top: 0.2em;
-    vertical-align: -0.3em;
-}
-
-.emote {
-    height: 1.45em;
-}
-
-.emote.jumboable {
-    height: 2rem;
-}
-
-.fav {
-    display: none;
-    position: absolute;
-    width: 15px;
-    height: 15px;
-    right: -7px;
-    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAzFBMVEUAAABQUFBMTExLS0tNTU1MTExNTU1NTU1MTExMTExNTU1LS0tEREBEREBEREBEREBJSUhLS0tLS0tEREBNTU1NTU1NTU1EREArKyhNTU1NTU0AAABMTExKSklMTExNTU1NTU1NTU1KSkpMTExKSkhNTU1KSkpISEZNTU1LS0tAQDxOTk5KSkpLS0tNTU1MTExMTEx/f39MTExMTExLS0pLS0tMTExNTU1NTU1LS0pNTU1NTU1NTU1NTU1NTU1NTUxNTU1NTU1NTUxMTEzB8C/5AAAAOnRSTlMAI8X96oWAgYSF68QBAg0PMCb9BIuLgQUD4N0Bh0mKhZSOQ4gcrKscaW8QRE6fmJyjAshASceG7cIpqQOxTQAAALVJREFUGFddx6FOA0EYAOGZvd07Qm6vVCAAgUUgQEDfX/YZMAigqaFN7iC5tsmPqGPUN/AvUVeoEbGOCElJz08Uzeixqu4AqomVVSNngOVjTqDGZSl3UFtPGV2ot2zaq96YM9p5Ddzcf/nTTAlj+/sNtNu8OcwkIsbPBtrUfMQeEhGQmHbmGIFMwLPzu6UMIwBNgToshgq8Nr2ki+Oy7ebDHp70LRPWB6OZgfWLWei7fJonOOsPCGA9kVlssOoAAAAASUVORK5CYII=");
-    border: none;
-    background-size: 100% 100%;
-    background-repeat: no-repeat;
-    background-color: #303030;
-    border-radius: 5px;
-    top: -7px;
-    cursor: pointer;
-}
-
-.fav.active {
-    background-color: yellow;
-}
-
-.emotewrapper:hover .fav {
-    display: block;
-}
-
-.emojiPicker-3m1S-j {
-    box-shadow: none;
-    border-top: none;
-    border-radius: 0 0 5px 5px;
-}
-
-#bd-qem {
-    border-radius: 5px 5px 0 0;
-    background: #fff;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    height: 30px;
-    display: flex;
-    flex-direction: row;
-    padding-right: 1px;
-}
-
-#bd-qem button {
-    border-left: 1px solid #efefef;
-    background: transparent;
-    box-shadow: #cecece 1px 0 0 0;
-    flex-grow: 1;
-}
-
-#bd-qem button:hover {
-    background: #ececec;
-}
-
-#bd-qem-twitch {
-    border-radius: 5px 0 0 0;
-    order: 2;
-}
-
-#bd-qem-emojis {
-    border-radius: 0 5px 0 0;
-    order: 3;
-}
-
-#bd-qem-favourite {
-    order: 3;
-}
-
-#bd-qem button.active {
-    background-color: #e2e2e2;
-}
-
-#bd-emote-menu {
-    width: 346px;
-    height: 329px;
-    background-color: #fff;
-    border-radius: 0 0 5px 5px;
-}
-
-#bd-emote-menu .scrollerBase-289Jih {
-    height: 100%;
+.bd-emote-menu {
+    min-height: 0;
 }
 
 .bd-emote-menu-inner {
-    padding: 5px 0 0 15px;
+    padding: 8px 0 0 16px;
 }
 
-.bd-qme-hidden #bd-qem-emojis {
-    display: none;
+.bd-emote-scroller {
+    height: 100%;
 }
 
-.bd-em-scroller {
-    height: 400px;
+.bd-emote-header {
+    display: flex;
+    align-items: center;
+    background: var(--background-secondary);
+    height: 32px;
+    padding: 0 4px;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+.bd-emote-header-inner {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    color: var(--header-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    transition: color 0.125s;
+    width: fit-content;
+}
+
+.bd-emote-header-inner:hover {
+    color: var(--header-primary);
+}
+
+.bd-emote-header-icon {
+    width: 16px;
+    height: 16px;
+}
+
+.bd-emote-header-icon svg {
+    max-height: 100%;
+    max-width: 100%;
+}
+
+.bd-emote-header-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+    margin: 0 8px;
+}
+
+.bd-emote-collapse-icon svg {
+    transition: transform 0.1s;
+}
+
+.bd-emote-collapse-icon.bd-open svg {
+    transform: rotate(-90deg);
+}
+
+.bd-emote-item {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2px;
+    border-radius: 5px;
+    width: 30px;
+    height: 30px;
+    position: relative;
+}
+
+.bd-emote-item:hover {
+    background: var(--background-accent);
+}
+
+.bd-emote-item img {
+    max-width: 100%;
 }

--- a/src/styles/builtins/emotes.css
+++ b/src/styles/builtins/emotes.css
@@ -1,95 +1,51 @@
-.bd-emote-header {
-    color: var(--header-secondary);
-    justify-content: flex-start;
-    font-size: 12px;
-    font-weight: 600;
-    transition: color 0.125s;
-    align-items: center;
-    display: flex;
-}
-
-.bd-emote-scroller {
-    max-height: 380px;
-}
-
-.bd-emote-category {
-    margin-bottom: 12px;
-}
-
-.bd-emote-content {
-    cursor: pointer;
-    position: sticky;
-    top: 0;
-    background: var(--background-secondary);
-    z-index: 2;
-}
-
-.bd-emote-wrapper {
-    background-color: var(--background-secondary);
-    box-sizing: border-box;
-    height: 32px;
-    padding: 0 4px;
-    z-index: 1;
-}
-
-.bd-emote-headerIcon {
-    width: 14px;
-    height: 14px;
-    margin-right: 8px;
-}
-
-.bd-emote-headerLabel {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-transform: uppercase;
-    white-space: nowrap;
-    margin-right: 8px;
-}
-
-.bd-emote-headerIcon + .bd-emote-headerLabel {
-    margin-left: 8px;
-}
-
-.bd-emote-headerCollapseIcon .bd-emote-opened {
-    transition: 0.3s;
-}
-
-.bd-emote-headerCollapseIcon .bd-emote-closed {
-    transform: rotate(90deg);
-    transition: 0.3s;
-}
-
-#emote-container {
-    padding: 10px;
-}
-
-.emote-container {
-    display: inline-block;
-    padding: 2px;
-    border-radius: 5px;
-    width: 30px;
-    height: 30px;
+.emotewrapper {
     position: relative;
+    display: inline-flex;
+    object-fit: contain;
+    margin: -0.1em 0.05em -0.2em 0.1em;
+    vertical-align: top;
 }
 
-.emote-icon {
-    max-width: 100%;
-    max-height: 100%;
+.emotewrapper.jumboable {
+    margin-bottom: 0;
+    margin-top: 0.2em;
+    vertical-align: -0.3em;
+}
+
+.emote {
+    height: 1.45em;
+}
+
+.emote.jumboable {
+    height: 2rem;
+}
+
+.fav {
+    display: none;
     position: absolute;
-    margin: auto;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    width: 15px;
+    height: 15px;
+    right: -7px;
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAzFBMVEUAAABQUFBMTExLS0tNTU1MTExNTU1NTU1MTExMTExNTU1LS0tEREBEREBEREBEREBJSUhLS0tLS0tEREBNTU1NTU1NTU1EREArKyhNTU1NTU0AAABMTExKSklMTExNTU1NTU1NTU1KSkpMTExKSkhNTU1KSkpISEZNTU1LS0tAQDxOTk5KSkpLS0tNTU1MTExMTEx/f39MTExMTExLS0pLS0tMTExNTU1NTU1LS0pNTU1NTU1NTU1NTU1NTU1NTUxNTU1NTU1NTUxMTEzB8C/5AAAAOnRSTlMAI8X96oWAgYSF68QBAg0PMCb9BIuLgQUD4N0Bh0mKhZSOQ4gcrKscaW8QRE6fmJyjAshASceG7cIpqQOxTQAAALVJREFUGFddx6FOA0EYAOGZvd07Qm6vVCAAgUUgQEDfX/YZMAigqaFN7iC5tsmPqGPUN/AvUVeoEbGOCElJz08Uzeixqu4AqomVVSNngOVjTqDGZSl3UFtPGV2ot2zaq96YM9p5Ddzcf/nTTAlj+/sNtNu8OcwkIsbPBtrUfMQeEhGQmHbmGIFMwLPzu6UMIwBNgToshgq8Nr2ki+Oy7ebDHp70LRPWB6OZgfWLWei7fJonOOsPCGA9kVlssOoAAAAASUVORK5CYII=");
+    border: none;
+    background-size: 100% 100%;
+    background-repeat: no-repeat;
+    background-color: #303030;
+    border-radius: 5px;
+    top: -7px;
     cursor: pointer;
+}
+
+.fav.active {
+    background-color: yellow;
+}
+
+.emotewrapper:hover .fav {
+    display: block;
 }
 
 .emote.stop-animation {
     animation: none;
-}
-
-.emote-container:hover {
-    background: rgba(123, 123, 123, 0.37);
 }
 
 .emoteflip,

--- a/src/styles/builtins/publicservers.css
+++ b/src/styles/builtins/publicservers.css
@@ -64,7 +64,28 @@
     position: relative;
     transition: box-shadow 0.2s ease-out, transform 0.2s ease-out, background 0.2s ease-out, opacity 0.2s ease-in;
     cursor: pointer;
+    background-color: var(--activity-card-background);
+}
+
+.bd-server-card:hover,
+.bd-server-card:focus,
+.theme-light .bd-server-card:hover,
+.theme-light .bd-server-card:focus {
+    transform: translateY(-1px);
+    box-shadow: var(--elevation-high);
+}
+
+.theme-light .bd-server-card {
+    box-shadow: 0 0 0 1px rgba(185,187,190,.3), var(--elevation-medium);
+}
+
+.theme-dark .bd-server-card {
     background-color: var(--background-secondary-alt);
+}
+
+.theme-dark .bd-server-card:hover,
+.theme-dark .bd-server-card:focus {
+    background-color: var(--background-tertiary);
 }
 
 .bd-placeholder-card {
@@ -75,12 +96,6 @@
     overflow: hidden;
     border-radius: 8px;
     position: relative;
-}
-
-.bd-server-card:hover {
-    background-color: var(--background-tertiary);
-    transform: translateY(-1px);
-    box-shadow: var(--elevation-high);
 }
 
 .bd-server-header {
@@ -166,7 +181,7 @@
     -webkit-box-orient: vertical;
     color: var(--header-secondary);
     font-size: 14px;
-    line-height: 18px;
+    line-height: normal;
 }
 
 .bd-server-footer {

--- a/src/styles/builtins/publicservers.css
+++ b/src/styles/builtins/publicservers.css
@@ -67,20 +67,20 @@
     background-color: var(--activity-card-background);
 }
 
+.theme-light .bd-server-card {
+    box-shadow: 0 0 0 1px rgba(185, 187, 190, 0.3), var(--elevation-medium);
+}
+
+.theme-dark .bd-server-card {
+    background-color: var(--background-secondary-alt);
+}
+
 .bd-server-card:hover,
 .bd-server-card:focus,
 .theme-light .bd-server-card:hover,
 .theme-light .bd-server-card:focus {
     transform: translateY(-1px);
     box-shadow: var(--elevation-high);
-}
-
-.theme-light .bd-server-card {
-    box-shadow: 0 0 0 1px rgba(185,187,190,.3), var(--elevation-medium);
-}
-
-.theme-dark .bd-server-card {
-    background-color: var(--background-secondary-alt);
 }
 
 .theme-dark .bd-server-card:hover,

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -5,7 +5,7 @@
     background-color: #3e82e5;
     color: #fff;
     border-radius: 3px;
-    padding: 3px 6px;
+    padding: 4px 8px;
     transition: opacity 250ms ease;
 }
 

--- a/src/styles/ui/addonlist.css
+++ b/src/styles/ui/addonlist.css
@@ -148,6 +148,7 @@
 
 .bd-controls > .bd-addon-button {
     border-radius: 0;
+    padding: 3px 6px;
 }
 
 .bd-links .bd-addon-button + .bd-addon-button {
@@ -164,6 +165,10 @@
 
 .bd-controls > .bd-addon-button:last-of-type {
     border-radius: 0 3px 3px 0;
+}
+
+.bd-controls > .bd-addon-button:only-child {
+    border-radius: 3px;
 }
 
 .bd-controls + .bd-addon-list {

--- a/src/ui/emoteicon.jsx
+++ b/src/ui/emoteicon.jsx
@@ -8,7 +8,7 @@ const {ComponentDispatch} = WebpackModules.getByProps("ComponentDispatch");
 
 export default class EmoteIcon extends React.Component {
     render() {
-        return <div className="emote-container" onClick={this.handleOnClick.bind(this)} onContextMenu={this.handleOnContextMenu.bind(this)}>
+        return <div className="bd-emote-item" onClick={this.handleOnClick.bind(this)} onContextMenu={this.handleOnContextMenu.bind(this)}>
             <img src={this.props.url} alt={this.props.emote} title={this.props.emote}/>
         </div>;
     }

--- a/src/ui/emotemenucard.jsx
+++ b/src/ui/emotemenucard.jsx
@@ -3,7 +3,7 @@ const {ScrollerAuto: Scroller} = WebpackModules.getByProps("ScrollerAuto");
 export default class EmoteMenuCard extends React.Component {
     render() {
         return <div className={`bd-emote-menu`}>
-            <Scroller className="bd-emote-scroller thin-1ybCId">
+            <Scroller className="bd-emote-scroller">
                 <div className="bd-emote-menu-inner">
                     {this.props.children}
                 </div>

--- a/src/ui/emotemenucard.jsx
+++ b/src/ui/emotemenucard.jsx
@@ -3,7 +3,7 @@ const {ScrollerAuto: Scroller} = WebpackModules.getByProps("ScrollerAuto");
 export default class EmoteMenuCard extends React.Component {
     render() {
         return <div className={`bd-emote-menu`}>
-            <Scroller className="bd-emote-scroller">
+            <Scroller className="bd-emote-scroller thin-1ybCId">
                 <div className="bd-emote-menu-inner">
                     {this.props.children}
                 </div>

--- a/src/ui/icons/downarrow.jsx
+++ b/src/ui/icons/downarrow.jsx
@@ -3,7 +3,7 @@ import {React} from "modules";
 export default class DownArrow extends React.Component {
     render() {
         const size = this.props.size || "16px";
-        return <svg className={this.props.className || ""} fill="#FFFFFF" viewBox="0 0 24 24" style={{width: size, height: size}}>
+        return <svg className={this.props.className || ""} fill="currentColor" viewBox="0 0 24 24" style={{width: size, height: size}}>
                     <path d="M8.12 9.29L12 13.17l3.88-3.88c.39-.39 1.02-.39 1.41 0 .39.39.39 1.02 0 1.41l-4.59 4.59c-.39.39-1.02.39-1.41 0L6.7 10.7c-.39-.39-.39-1.02 0-1.41.39-.38 1.03-.39 1.42 0z"/>
                 </svg>;
     }


### PR DESCRIPTION
This PR rewrites a good portion of the new emote system (mainly UI related fixes).
- Light mode support
- A lot of consistency fixes (arrows flipping the wrong directions, coloring, interaction, spacing, classnames, etc...)
- Removal of some old or redundant code
- Class restructure in the emote picker.

This doesn't affect the emote components in chat. I'd be willing to rewrite them, but it looks like the `.jumboable` classname is broken and therefore i can't do much to make it consistent with discord's design.