### PR TITLE
Apply z-index to modal wrapper

### DIFF
--- a/renderer/src/styles/ui/modals.css
+++ b/renderer/src/styles/ui/modals.css
@@ -39,6 +39,10 @@
     opacity: 0.85;
 }
 
+.bd-modal-wrapper {
+    z-index: 1000;
+}
+
 .bd-modal-wrapper .bd-modal {
     animation: bd-modal-wrapper 250ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
     animation-fill-mode: forwards;
@@ -56,7 +60,6 @@
     opacity: 0;
     pointer-events: none;
     position: absolute;
-    z-index: 1000;
 }
 
 .bd-modal-wrapper.closing .bd-modal {


### PR DESCRIPTION
Currently, the backdrop of the modal does not get a z-index, causing elements in the Discord UI that have a z-index to appear on top of it:

![image](https://user-images.githubusercontent.com/42590338/113724347-40cd0f80-96c0-11eb-8e5d-52ce59ee2ae4.png)

To fix this, the z-index should be applied to the modal wrapper, rather than the modal itself, which also contains the backdrop:

![image](https://user-images.githubusercontent.com/42590338/113724393-4aef0e00-96c0-11eb-9629-cf4836a16983.png)