### PR TITLE
Add compatibility with electron versions above 9.0.0

### DIFF
--- a/renderer/src/modules/addonmanager.js
+++ b/renderer/src/modules/addonmanager.js
@@ -343,7 +343,10 @@ export default class AddonManager {
         const addon = typeof(idOrFileOrAddon) == "string" ? this.addonList.find(c => c.id == idOrFileOrAddon || c.filename == idOrFileOrAddon) : idOrFileOrAddon;
         const fullPath = path.resolve(this.addonFolder, addon.filename);
         if (typeof(system) == "undefined") system = Settings.get("settings", "addons", "editAction") == "system";
-        if (system) return require("electron").shell.openItem(`${fullPath}`);
+        if (system) {
+            const shell = require("electron").shell;
+            return (shell.openItem || shell.openPath)(`${fullPath}`);
+        }
         return this.openDetached(addon);
     }
 


### PR DESCRIPTION
Add call to `shell.openPath` if `shell.openItem` is not found when editing themes or plugins using the system editor using the same approach as [addonlist.jsx](https://github.com/rauenzi/BetterDiscordApp/blob/main/renderer/src/ui/settings/addonlist.jsx).

Now the old or the updated method get called depending on availability which resolves an error thrown when trying to edit plugins in the system editor because `shell.openItem` has been removed from newer electron versions. See [this](https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md) for the reason for the deprecation and removal of `shell.openItem`.
