### PR TITLE
Add support for other chrome profiles in reactdevtools.js

### DIFF
--- a/injector/src/modules/reactdevtools.js
+++ b/injector/src/modules/reactdevtools.js
@@ -6,11 +6,35 @@ export const REACT_DEVTOOLS_ID = "fmkadmapgofadopljbjfkapdkoienihi";
 
 const findExtension = function() {
     let extensionPath = "";
+    // Get path to user data folder
     if (process.platform === "win32") extensionPath = path.resolve(process.env.LOCALAPPDATA, "Google/Chrome/User Data");
     else if (process.platform === "linux") extensionPath = path.resolve(process.env.HOME, ".config/google-chrome");
     else if (process.platform === "darwin") extensionPath = path.resolve(process.env.HOME, "Library/Application Support/Google/Chrome");
     else extensionPath = path.resolve(process.env.HOME, ".config/chromium");
-    extensionPath += `/Default/Extensions/${REACT_DEVTOOLS_ID}`;
+
+    // If default profile doesn't exist
+    if (!fs.existsSync(extensionPath + "/Default")) {
+        const profiles = fs.readdirSync(extensionPath).filter((fileName) => {
+            // Check if file is a profile folder
+            return fileName.startsWith("Profile") && !fileName.endsWith("store");
+        });
+        // Check for a profile with react dev tools installed
+        let foundExtension = false;
+        for (const p of profiles) {
+            const exPath = `${extensionPath}/${p}/Extensions/${REACT_DEVTOOLS_ID}`;
+            if (fs.existsSync(exPath)) {
+                extensionPath = exPath;
+                foundExtension = true;
+                break;
+            }
+        }
+        // Return empty if no installation found
+        if (!foundExtension)
+            return "";
+        
+    } else extensionPath += `/Default/Extensions/${REACT_DEVTOOLS_ID}`;
+    
+    // Get latest version
     if (fs.existsSync(extensionPath)) {
         const versions = fs.readdirSync(extensionPath);
         extensionPath = path.resolve(extensionPath, versions[versions.length - 1]);

--- a/injector/src/modules/reactdevtools.js
+++ b/injector/src/modules/reactdevtools.js
@@ -29,10 +29,13 @@ const findExtension = function() {
             }
         }
         // Return empty if no installation found
-        if (!foundExtension)
+        if (!foundExtension) {
             return "";
-        
-    } else extensionPath += `/Default/Extensions/${REACT_DEVTOOLS_ID}`;
+        }
+    }
+    else {
+        extensionPath += `/Default/Extensions/${REACT_DEVTOOLS_ID}`;
+    } 
     
     // Get latest version
     if (fs.existsSync(extensionPath)) {


### PR DESCRIPTION
This adds support for other profiles. For example, I don't have `.../User Data/Default` but have `.../User Data/Profile 5`.