### PR TITLE
Fix user config path for flatpak

### DIFF
--- a/src/betterdiscord/polyfill/fs.ts
+++ b/src/betterdiscord/polyfill/fs.ts
@@ -35,7 +35,7 @@ export const writeFile = function (path: string, data: string | Uint8Array, opti
     }
 };
 
-export const writeFileSync = function (path: string, data: string | Uint8Array, options: WriteFileOptions & {originalFs: boolean;}) {
+export const writeFileSync = function (path: string, data: string | Uint8Array, options?: WriteFileOptions & {originalFs: boolean;}) {
     Remote.filesystem.writeFile(path, data, options);
 };
 

--- a/src/electron/preload/api/filesystem.ts
+++ b/src/electron/preload/api/filesystem.ts
@@ -9,7 +9,7 @@ export function readFile(path: string, options: object | BufferEncoding = "utf8"
     return fs.readFileSync(path, options);
 }
 
-export function writeFile(path: string, content: string | Uint8Array, options: fs.WriteFileOptions & {originalFs: boolean;}) {
+export function writeFile(path: string, content: string | Uint8Array, options?: fs.WriteFileOptions & {originalFs: boolean;}) {
     if (content instanceof Uint8Array) {
         content = Buffer.from(content);
     }

--- a/src/electron/preload/discordnativepatch.ts
+++ b/src/electron/preload/discordnativepatch.ts
@@ -3,10 +3,21 @@ import path from "path";
 
 import * as IPCEvents from "@common/constants/ipcevents";
 
-let dataPath = "";
-if (process.platform === "win32" || process.platform === "darwin") dataPath = path.join(electron.ipcRenderer.sendSync(IPCEvents.GET_PATH, "userData"), "..");
-else dataPath = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME!, ".config"); // This will help with snap packages eventually
-dataPath = path.join(dataPath, "BetterDiscord") + "/";
+
+// Windows and macOS both use the fixed global BetterDiscord folder but
+// Electron gives the postfixed version of userData, so go up a directory
+let userConfig = path.join(electron.ipcRenderer.sendSync(IPCEvents.GET_PATH, "userData"), "..");
+
+// If we're on Linux there are a couple cases to deal with
+if (process.platform !== "win32" && process.platform !== "darwin") {
+    // Use || instead of ?? because a falsey value of "" is invalid per XDG spec
+    userConfig = process.env.XDG_CONFIG_HOME || path.join(process.env.HOME!, ".config");
+
+    // HOST_XDG_CONFIG_HOME is set by flatpak, so use without validation if set
+    if (process.env.HOST_XDG_CONFIG_HOME) userConfig = process.env.HOST_XDG_CONFIG_HOME;
+}
+
+const dataPath = path.join(userConfig, "BetterDiscord") + "/";
 
 let _settings: Record<string, Record<string, any>>;
 function getSetting(category: string, key: string) {


### PR DESCRIPTION
Our new install process for Discord flatpak on linux is to use `flatpak override` to grant Discord access to the "global" BetterDiscord install. Flatpak sets the `HOST_XDG_CONFIG_HOME` environment variable that we can use here to distinguish between "global" and "local" installs. 

The only potential issue is this __may break existing flatpak installs__ that were injected with BD by `betterdiscordctl`. I'm not sure how that script handled flatpak.