### PR TITLE
Fix startup toast counting deleted plugins

### DIFF
--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -415,7 +415,7 @@ export default abstract class AddonManager extends Store {
             }
             const addon = this.loadAddon(filename, false);
             if (addon instanceof AddonError) errors.push(addon);
-            else if(addon !== false) this.initialAddonsLoaded++;
+            else if (addon !== false) this.initialAddonsLoaded++;
         }
 
         this.saveState();


### PR DESCRIPTION
Because AddonManager's state still tracks addons that no longer exist it is  possible for the startup toast to report that more addons were loaded than there actually were. This pr makes it so that it counts properly.