### PR TITLE
customCss error fix

### DIFF
--- a/src/betterdiscord/builtins/customcss.ts
+++ b/src/betterdiscord/builtins/customcss.ts
@@ -89,6 +89,15 @@ export default new class CustomCSS extends Builtin {
 
     watchContent() {
         if (this.watcher) return this.error("Already watching content.");
+        if (!fs.existsSync(this.file)) {
+            try {
+                fs.mkdirSync(path.dirname(this.file), {recursive: true});
+                fs.writeFileSync(this.file, "");
+            }
+            catch (err) {
+                return this.error("Could not create custom.css file.", err);
+            }
+        }
         const timeCache: Record<string, number> = {};
         this.log("Starting to watch content.");
         this.watcher = fs.watch(this.file, {persistent: false}, async (eventType, filename) => {


### PR DESCRIPTION
Creates `custom.css` if one doesnt exist already, to stop this;

<img width="548" height="159" alt="image" src="https://github.com/user-attachments/assets/1525899a-c99c-44aa-93ba-ea6c7d5d5094" />
