### PR TITLE
Fixes `object Object` aria-label

### DIFF
--- a/src/betterdiscord/ui/settings.tsx
+++ b/src/betterdiscord/ui/settings.tsx
@@ -415,7 +415,7 @@ export default new class SettingsRenderer {
 
                 return layouts;
             },
-            useLabel: () => Object.assign(<LayerSettingTitle />, { toString: () => "BetterDiscord" }),
+            useLabel: () => Object.assign(<LayerSettingTitle />, {toString: () => "BetterDiscord"}),
         });
 
         Patcher.after("SettingsManager", rootLayout, "buildLayout", (that, args, res) => {


### PR DESCRIPTION
Fixes `object Object` aria-label for BetterDiscord section in the settings panel