### PR TITLE
Ignore errors from git in build script

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,8 +9,8 @@ const fileURL = Bun.fileURLToPath(import.meta.url);
 const rootDir = path.join(path.dirname(fileURL), "..");
 const isProduction = process.argv.includes("--minify");
 
-const BRANCH_NAME = Bun.env.BRANCH_NAME ?? (await $`git symbolic-ref --short HEAD`.quiet().text()).trim();
-const COMMIT_HASH = Bun.env.COMMIT_HASH ?? (await $`git rev-parse --short HEAD`.quiet().text()).trim();
+const BRANCH_NAME = Bun.env.BRANCH_NAME ?? (await $`git symbolic-ref --short HEAD`.quiet().nothrow().text()).trim();
+const COMMIT_HASH = Bun.env.COMMIT_HASH ?? (await $`git rev-parse --short HEAD`.quiet().nothrow().text()).trim();
 const DEVELOPMENT = Bun.env.NODE_ENV ?? "development";
 
 interface EntryPoint {


### PR DESCRIPTION
This PR adds `.nothrow()` to the `git` shell commands, which suppresses any errors that may arise from detecting the branch name or commit hash. Errors may happen if checked out to a specific tag, or if built from a non-repo tarball, so without this patch building fails with a `ShellError` thrown. Adding these calls makes the commands succeed with an empty response, which isn't a problem for these variables.