### PR TITLE
Fix settings panel for Discord's changes

### DIFF
--- a/src/betterdiscord/ui/settings.tsx
+++ b/src/betterdiscord/ui/settings.tsx
@@ -262,7 +262,7 @@ export default new class SettingsRenderer {
         const rootLayout = await getLazy<{
             key: "$Root";
             buildLayout(): SectionLayout[];
-        }>(m => m?.key === "$Root");
+        }>(m => m?.key === "$Root", {searchExports: true, searchDefault: false});
         if (!rootLayout) return;
 
         this.patchSettingsSearch();


### PR DESCRIPTION
This pull request makes a minor update to how the `$Root` layout is loaded in the settings renderer. The change improves module lookup by specifying search options for the `getLazy` function.