### PR TITLE
Native Frame Default False

### DIFF
--- a/src/betterdiscord/data/settings.ts
+++ b/src/betterdiscord/data/settings.ts
@@ -75,7 +75,7 @@ const DefaultSettings = [
         settings: [
             {type: "switch", id: "transparency", value: false},
             {type: "switch", id: "removeMinimumSize", value: false},
-            {type: "switch", id: "frame", value: process.platform === "linux"},
+            {type: "switch", id: "frame", value: false},
             // MacOS exclusive
             {type: "switch", id: "inAppTrafficLights", value: false, disabled: process.env.BETTERDISCORD_NATIVE_FRAME === "true", hidden: process.platform !== "darwin"}
         ]


### PR DESCRIPTION
Setting the Native Frame setting to be false by default, since Discord now uses custom CSD on Linux as well. 
That made discord's behavior consistent with other operating systems, so the default should match theirs.