### PR TITLE
Make preventDefault() cancel toggling for toggle items created through ContextMenu api

### DIFF
--- a/src/betterdiscord/api/contextmenu.ts
+++ b/src/betterdiscord/api/contextmenu.ts
@@ -282,9 +282,9 @@ class ContextMenu {
             const [active, doToggle] = React.useState(props.checked || false);
             const originalAction = props.action;
             props.checked = active;
-            props.action = function (ev) {
+            props.action = function (ev: React.MouseEvent) {
                 originalAction(ev);
-                doToggle(!active);
+                if (!ev.defaultPrevented) doToggle(!active);
             };
         }
 


### PR DESCRIPTION
This allows for a toggle to be cancelled by calling preventDefault, like so:

```js
BdApi.ContextMenu.buildItem({
    type: "toggle",
    label: "test",
    active: true,
    action: (e) => { e.preventDefault(); console.log("here") }
})
```