### PR TITLE
Mini restructure to `tags` to be inline with the other dropdowns

### DIFF
--- a/src/betterdiscord/ui/settings/addonstore.tsx
+++ b/src/betterdiscord/ui/settings/addonstore.tsx
@@ -104,7 +104,6 @@ function TagDropdown({type, selected, onChange}) {
                 popover="auto"
                 role="listbox"
                 className="bd-select-options"
-                onClick={(e) => e.stopPropagation()}
             >
                 {tags.map((tag, index) => {
                     const isSelected = selectedTags.includes(tag);


### PR DESCRIPTION
Mini restructure to `tags` to be inline with the other dropdowns in the built-in addon store.