### PR TITLE
fix: add z-index to select dropdown to appear above addon cards

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "betterdiscord",

--- a/src/betterdiscord/styles/ui/bdsettings.css
+++ b/src/betterdiscord/styles/ui/bdsettings.css
@@ -83,6 +83,7 @@
   margin-top: 4px;
   overflow: auto scroll;
   border: 1px solid var(--input-border-default);
+  z-index: 1000;
 }
 
 .bd-select-option {


### PR DESCRIPTION
## Summary

Fixes the tags dropdown menu in the Addons Store appearing beneath addon cards.

## Changes

Added `z-index: 1000` to `.bd-select-options` in `bdsettings.css` to ensure the popover appears above other content like addon cards.

## Testing

- Build passes
- The dropdown now correctly appears above addon cards when opened

Fixes #2096