### PR TITLE
Feat/other mod warning

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -42,7 +42,7 @@ function buildOptions() {
         alias: {
             react: "@modules/react",
         },
-        external: ["fs", "original-fs", "path", "vm", "electron", "@electron/remote", "module", "request", "events", "child_process", "net", "http", "https", "crypto", "os", "url"],
+        external: ["fs", "original-fs", "path", "vm", "electron", "@electron/remote", "module", "request", "events", "child_process", "net", "http", "https", "crypto", "os", "url", "util/types"],
         target: ["chrome128", "node20"],
         loader: {
             ".js": "jsx",

--- a/src/betterdiscord/modules/ipc.ts
+++ b/src/betterdiscord/modules/ipc.ts
@@ -65,4 +65,16 @@ export default new class IPCRenderer {
     openPath(path: string) {
         return ipc.send(IPCEvents.OPEN_PATH, path);
     }
+
+    allowPreloadOverride = {
+        async set(value: boolean) {
+            await ipc.invoke(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, value);
+        },
+        async get(): Promise<boolean> {
+            return ipc.invoke(IPCEvents.GET_ALLOW_PRELOAD_OVERRIDE);
+        },
+        async toggle() {
+            await ipc.invoke(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, !await this.get());
+        }
+    };
 };

--- a/src/betterdiscord/ui/modals/changelog.tsx
+++ b/src/betterdiscord/ui/modals/changelog.tsx
@@ -16,7 +16,6 @@ import Modals from "@ui/modals";
 import {GithubIcon, TwitterIcon} from "lucide-react";
 import type {MouseEvent, ReactNode} from "react";
 import {getByKeys} from "@webpack";
-import RemoteAPI from "@polyfill/remote";
 import ipc from "@modules/ipc";
 
 const {useMemo} = React;
@@ -40,7 +39,7 @@ const toggleAllowingOtherClientMods = async (click: MouseEvent) => {
         click.preventDefault();
         click.stopPropagation();
 
-        await RemoteAPI.allowPreloadOverride.toggle();
+        await ipc.allowPreloadOverride.toggle();
         ipc.relaunch();
     }
 };

--- a/src/betterdiscord/ui/modals/changelog.tsx
+++ b/src/betterdiscord/ui/modals/changelog.tsx
@@ -16,6 +16,8 @@ import Modals from "@ui/modals";
 import {GithubIcon, TwitterIcon} from "lucide-react";
 import type {MouseEvent, ReactNode} from "react";
 import {getByKeys} from "@webpack";
+import RemoteAPI from "@polyfill/remote";
+import ipc from "@modules/ipc";
 
 const {useMemo} = React;
 
@@ -32,8 +34,19 @@ const joinSupportServer = (click: MouseEvent) => {
     DiscordModules.Dispatcher?.dispatch({type: "LAYER_POP"});
 };
 
+const toggleAllowingOtherClientMods = async (click: MouseEvent) => {
+    // if triple click toggle it
+    if (click.detail === 3) {
+        click.preventDefault();
+        click.stopPropagation();
+
+        await RemoteAPI.allowPreloadOverride.toggle();
+        ipc.relaunch();
+    }
+};
+
 const supportLink = <a className={`${AnchorClasses.anchor} ${AnchorClasses.anchorUnderlineOnHover}`} onClick={joinSupportServer}>Join our Discord Server.</a>;
-const defaultFooter = <Text>Need support? {supportLink}</Text>;
+const defaultFooter = <Text><span onClick={toggleAllowingOtherClientMods}>Need support?</span> {supportLink}</Text>;
 
 const twitter = <DiscordModules.Tooltip color="primary" position="top" text={t("Socials.twitter")}>
     {p => <a {...p} className="bd-social" href="https://x.com/_BetterDiscord_" rel="noopener noreferrer" target="_blank">

--- a/src/betterdiscord/webpack/require.ts
+++ b/src/betterdiscord/webpack/require.ts
@@ -24,6 +24,9 @@ Object.defineProperty(window.webpackChunkdiscord_app, "push", {
 
 function listenToModules(modules: Record<PropertyKey, RawModule>) {
     for (const moduleId in modules) {
+        if (!Reflect.has(modules, moduleId)) continue;
+        if (Reflect.has(webpackRequire.c, moduleId)) continue;
+
         const originalModule = modules[moduleId];
 
         const runListeners: Webpack.RawModule = (module, exports, require) => {
@@ -54,8 +57,11 @@ function listenToModules(modules: Record<PropertyKey, RawModule>) {
             }
         };
 
+
+        const stringed = String(originalModule);
+
         Object.assign(modules[moduleId], originalModule, {
-            toString: () => originalModule.toString(),
+            toString: () => stringed,
             __BD__: {runListeners, originalModule}
         });
     }

--- a/src/common/constants/ipcevents.ts
+++ b/src/common/constants/ipcevents.ts
@@ -24,5 +24,5 @@ export const EDITOR_OPEN                = "bd-editor-open";
 export const EDITOR_SHOULD_SHOW_WARNING = "bd-editor-show-warning";
 export const EDITOR_SETTINGS_GET        = "bd-editor-settings-get";
 export const EDITOR_SETTINGS_UPDATE     = "bd-editor-settings-update";
-export const SET_ALLOW_PRELOAD_OVERRIDE = "set-bd-allow-preload-override";
-export const GET_ALLOW_PRELOAD_OVERRIDE = "get-bd-allow-preload-override";
+export const SET_ALLOW_PRELOAD_OVERRIDE = "bd-set-allow-preload-override";
+export const GET_ALLOW_PRELOAD_OVERRIDE = "bd-get-allow-preload-override";

--- a/src/common/constants/ipcevents.ts
+++ b/src/common/constants/ipcevents.ts
@@ -24,3 +24,5 @@ export const EDITOR_OPEN                = "bd-editor-open";
 export const EDITOR_SHOULD_SHOW_WARNING = "bd-editor-show-warning";
 export const EDITOR_SETTINGS_GET        = "bd-editor-settings-get";
 export const EDITOR_SETTINGS_UPDATE     = "bd-editor-settings-update";
+export const SET_ALLOW_PRELOAD_OVERRIDE = "set-bd-allow-preload-override";
+export const GET_ALLOW_PRELOAD_OVERRIDE = "get-bd-allow-preload-override";

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -38,6 +38,31 @@ export default class BetterDiscord {
         }
     }
 
+    static compatibilityWarning = {
+        shouldShow() {
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                const buildInfo = require(buildInfoFile);
+                const settingsFile = path.resolve(bdFolder, "data", buildInfo.releaseChannel, "compatibilityWarning.txt");
+
+                return fs.readFileSync(settingsFile, "utf-8") === "true";
+            }
+            catch {
+                return true;
+            }
+        },
+        stopShowing() {
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                const buildInfo = require(buildInfoFile);
+                const settingsFile = path.resolve(bdFolder, "data", buildInfo.releaseChannel, "compatibilityWarning.txt");
+
+                fs.writeFileSync(settingsFile, "true");
+            }
+            catch {/* empty */}
+        }
+    };
+
     static ensureDirectories() {
         const dataFolder = path.join(bdFolder, "data");
         if (!fs.existsSync(bdFolder)) fs.mkdirSync(bdFolder);
@@ -82,7 +107,7 @@ export default class BetterDiscord {
         }
 
         // @ts-expect-error adding new property, don't want to override object
-        process.env.DISCORD_PRELOAD = browserWindow.__originalPreload;
+        process.env.BD_DISCORD_PRELOAD = browserWindow.__originalPreload;
         process.env.DISCORD_APP_PATH = appPath;
         process.env.DISCORD_USER_DATA = electron.app.getPath("userData");
         process.env.BETTERDISCORD_DATA_PATH = bdFolder;
@@ -183,6 +208,6 @@ Object.defineProperty(global, "appSettings", {
 });
 
 declare global {
-    // eslint-disable-next-line no-var
+
     var appSettings: any;
 }

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -223,6 +223,7 @@ Object.defineProperty(global, "appSettings", {
             setting.set("MIN_WIDTH", 940);
             setting.set("MIN_HEIGHT", 500);
         }
+
         delete global.appSettings;
         global.appSettings = setting;
     },
@@ -231,6 +232,5 @@ Object.defineProperty(global, "appSettings", {
 });
 
 declare global {
-
-    var appSettings: any;
+    let appSettings: any;
 }

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -38,28 +38,51 @@ export default class BetterDiscord {
         }
     }
 
-    static compatibilityWarning = {
-        shouldShow() {
+    static clientModCompatibility = class ClientModCompatibility {
+        private static _settings: Record<string, any> | undefined = undefined;
+
+        private static getJSON() {
+            if (this._settings) return this._settings;
+
             try {
                 // eslint-disable-next-line @typescript-eslint/no-require-imports
                 const buildInfo = require(buildInfoFile);
-                const settingsFile = path.resolve(bdFolder, "data", buildInfo.releaseChannel, "compatibilityWarning.txt");
+                const settingsFile = path.resolve(bdFolder, "data", buildInfo.releaseChannel, "clientModCompatibility.json");
 
-                return fs.readFileSync(settingsFile, "utf-8") === "true";
+                return this._settings = JSON.parse(fs.readFileSync(settingsFile, "utf-8"));
             }
             catch {
-                return true;
+                return this._settings = {};
             }
-        },
-        stopShowing() {
+        }
+
+        private static writeJSON() {
             try {
                 // eslint-disable-next-line @typescript-eslint/no-require-imports
                 const buildInfo = require(buildInfoFile);
-                const settingsFile = path.resolve(bdFolder, "data", buildInfo.releaseChannel, "compatibilityWarning.txt");
+                const settingsFile = path.resolve(bdFolder, "data", buildInfo.releaseChannel, "clientModCompatibility.json");
 
-                fs.writeFileSync(settingsFile, "true");
+                fs.writeFileSync(settingsFile, JSON.stringify(this.getJSON()));
             }
             catch {/* empty */}
+        }
+
+        public static shouldShow(): boolean {
+            return this.getJSON().shouldShow ?? true;
+        }
+
+        public static allowPreloadOverride(): boolean {
+            return this.getJSON().allowPreloadOverride ?? false;
+        }
+
+        public static stopShowing() {
+            this.getJSON().shouldShow = false;
+            this.writeJSON();
+        }
+
+        public static setAllowPreloadOverride(allowPreloadOverride: boolean = false) {
+            this.getJSON().allowPreloadOverride = allowPreloadOverride;
+            this.writeJSON();
         }
     };
 

--- a/src/electron/main/modules/browserwindow.ts
+++ b/src/electron/main/modules/browserwindow.ts
@@ -28,8 +28,36 @@ class BrowserWindow extends electron.BrowserWindow {
      */
     constructor(options: BrowserWindowConstructorOptions) {
         if (!options || !options.webPreferences || !options.webPreferences.preload || !options.title) return super(options);
+
+        if (maybeHasOtherClientMod() && BetterDiscord.clientModCompatibility.shouldShow()) {
+            // Not i18n but the i18n system doesn't exist here
+            electron.dialog.showMessageBox({
+                type: "warning",
+                title: "BetterDiscord Compatibility Warning",
+                message: "BetterDiscord has detected another client mod. This may cause issues with BetterDiscord and/or the other mod. Please remove any other client mods to ensure the best experience.",
+                checkboxLabel: "Don't show this again",
+                buttons: ["OK"],
+                defaultId: 0,
+                cancelId: 1
+            }).then(result => {
+                if (result.checkboxChecked) {
+                    BetterDiscord.clientModCompatibility.stopShowing();
+                }
+            });
+        }
+
         const originalPreload = options.webPreferences.preload;
-        options.webPreferences.preload = path.join(__dirname, "preload.js");
+
+        let preload = options.webPreferences.preload = path.join(__dirname, "preload.js");
+
+        Object.defineProperty(options.webPreferences, "preload", {
+            get: () => preload,
+            set(newPreload) {
+                if (BetterDiscord.clientModCompatibility.allowPreloadOverride()) {
+                    preload = newPreload;
+                }
+            }
+        });
 
         // Don't allow just "truthy" values
         const shouldBeTransparent = BetterDiscord.getSetting("window", "transparency");
@@ -60,21 +88,6 @@ class BrowserWindow extends electron.BrowserWindow {
         this.__originalPreload = originalPreload;
         BetterDiscord.setup(this);
         Editor.initialize(this);
-
-        if (maybeHasOtherClientMod() && BetterDiscord.compatibilityWarning.shouldShow()) {
-            // Not i18n but the i18n system doesn't exist here
-            electron.dialog.showMessageBox({
-                type: "warning",
-                title: "BetterDiscord Compatibility Warning",
-                message: "BetterDiscord has detected another client mod. This may cause issues with BetterDiscord and/or the other mod. Please remove any other client mods to ensure the best experience.",
-                checkboxLabel: "Don't show this again",
-                buttons: ["OK"]
-            }).then(result => {
-                if (result.checkboxChecked) {
-                    BetterDiscord.compatibilityWarning.stopShowing();
-                }
-            });
-        }
 
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;

--- a/src/electron/main/modules/browserwindow.ts
+++ b/src/electron/main/modules/browserwindow.ts
@@ -4,8 +4,20 @@ import path from "path";
 import BetterDiscord from "./betterdiscord";
 import Editor from "./editor";
 import * as IPCEvents from "@common/constants/ipcevents";
+import {isProxy} from "util/types";
 
 // const EDITOR_URL_REGEX = /^betterdiscord:\/\/editor\/(?:custom-css|(theme|plugin)\/([^/]+))\/?/;
+
+function maybeHasOtherClientMod() {
+    if (isProxy(electron) || isProxy(electron.BrowserWindow)) return true;
+
+    const str = electron.BrowserWindow.toString();
+
+    const extendsIndex = str.indexOf("extends");
+
+    if (extendsIndex === -1) return false;
+    return extendsIndex < str.indexOf("{");
+}
 
 class BrowserWindow extends electron.BrowserWindow {
     private __originalPreload?: string;
@@ -48,6 +60,21 @@ class BrowserWindow extends electron.BrowserWindow {
         this.__originalPreload = originalPreload;
         BetterDiscord.setup(this);
         Editor.initialize(this);
+
+        if (maybeHasOtherClientMod() && BetterDiscord.compatibilityWarning.shouldShow()) {
+            // Not i18n but the i18n system doesn't exist here
+            electron.dialog.showMessageBox({
+                type: "warning",
+                title: "BetterDiscord Compatibility Warning",
+                message: "BetterDiscord has detected another client mod. This may cause issues with BetterDiscord and/or the other mod. Please remove any other client mods to ensure the best experience.",
+                checkboxLabel: "Don't show this again",
+                buttons: ["OK"]
+            }).then(result => {
+                if (result.checkboxChecked) {
+                    BetterDiscord.compatibilityWarning.stopShowing();
+                }
+            });
+        }
 
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;

--- a/src/electron/main/modules/browserwindow.ts
+++ b/src/electron/main/modules/browserwindow.ts
@@ -37,8 +37,7 @@ class BrowserWindow extends electron.BrowserWindow {
                 message: "BetterDiscord has detected another client mod. This may cause issues with BetterDiscord and/or the other mod. Please remove any other client mods to ensure the best experience.",
                 checkboxLabel: "Don't show this again",
                 buttons: ["OK"],
-                defaultId: 0,
-                cancelId: 1
+                defaultId: 0
             }).then(result => {
                 if (result.checkboxChecked) {
                     BetterDiscord.clientModCompatibility.stopShowing();

--- a/src/electron/main/modules/csp.ts
+++ b/src/electron/main/modules/csp.ts
@@ -1,8 +1,15 @@
 import electron from "electron";
 
 export default class {
+    static _onHeadersReceived: electron.WebRequest["onHeadersReceived"] | null = null;
+
+    static get onHeadersReceived() {
+        return this._onHeadersReceived ??= electron.session.fromPartition(`bd:${Date.now()}:${Math.random()}`).webRequest.onHeadersReceived;
+    }
+
     static remove() {
-        electron.session.defaultSession.webRequest.onHeadersReceived(function (details, callback) {
+        // electron.session.defaultSession.webRequest.onHeadersReceived may be redefined
+        this.onHeadersReceived.call(electron.session.defaultSession.webRequest, (details, callback) => {
             if (!details.responseHeaders) return callback({cancel: false});
 
             const headers = Object.keys(details.responseHeaders);
@@ -11,6 +18,7 @@ export default class {
                 if (key.toLowerCase().indexOf("content-security-policy") !== 0) continue;
                 delete details.responseHeaders[key];
             }
+
             callback({cancel: false, responseHeaders: details.responseHeaders});
         });
     }

--- a/src/electron/main/modules/ipc.ts
+++ b/src/electron/main/modules/ipc.ts
@@ -3,6 +3,7 @@ import {ipcMain as ipc, BrowserWindow, app, dialog, systemPreferences, shell, ty
 
 import * as IPCEvents from "@common/constants/ipcevents";
 import Editor from "./editor";
+import BetterDiscord from "./betterdiscord";
 
 const getPath = (event: IpcMainEvent, pathReq: string) => {
     let returnPath;
@@ -172,6 +173,14 @@ const getSettings = (event: IpcMainEvent) => {
     event.returnValue = Editor.getSettings();
 };
 
+const getAllowPreloadOverride = (_: IpcMainInvokeEvent) => {
+    return BetterDiscord.clientModCompatibility.allowPreloadOverride();
+};
+const setAllowPreloadOverride = (_: IpcMainInvokeEvent, value: boolean) => {
+    return BetterDiscord.clientModCompatibility.setAllowPreloadOverride(value);
+};
+
+
 export default class IPCMain {
     static registerEvents() {
         try {
@@ -193,6 +202,8 @@ export default class IPCMain {
             ipc.handle(IPCEvents.OPEN_WINDOW, createBrowserWindow);
             ipc.handle(IPCEvents.EDITOR_OPEN, openEditor);
             ipc.handle(IPCEvents.EDITOR_SETTINGS_UPDATE, updateSettings);
+            ipc.handle(IPCEvents.GET_ALLOW_PRELOAD_OVERRIDE, getAllowPreloadOverride);
+            ipc.handle(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, setAllowPreloadOverride);
         }
         catch (err) {
             // eslint-disable-next-line no-console

--- a/src/electron/preload/api/index.ts
+++ b/src/electron/preload/api/index.ts
@@ -35,16 +35,3 @@ export function addProtocolListener(callback: (a: string) => void) {
 export function setDevToolsWarningState(value: boolean) {
     DiscordNativePatch.setDevToolsWarningState(value);
 }
-
-
-export const allowPreloadOverride = {
-    async set(value: boolean) {
-        await electron.ipcRenderer.invoke(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, value);
-    },
-    async get(): Promise<boolean> {
-        return electron.ipcRenderer.invoke(IPCEvents.GET_ALLOW_PRELOAD_OVERRIDE);
-    },
-    async toggle() {
-        await electron.ipcRenderer.invoke(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, !await this.get());
-    }
-};

--- a/src/electron/preload/api/index.ts
+++ b/src/electron/preload/api/index.ts
@@ -35,3 +35,16 @@ export function addProtocolListener(callback: (a: string) => void) {
 export function setDevToolsWarningState(value: boolean) {
     DiscordNativePatch.setDevToolsWarningState(value);
 }
+
+
+export const allowPreloadOverride = {
+    async set(value: boolean) {
+        await electron.ipcRenderer.invoke(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, value);
+    },
+    async get(): Promise<boolean> {
+        return electron.ipcRenderer.invoke(IPCEvents.GET_ALLOW_PRELOAD_OVERRIDE);
+    },
+    async toggle() {
+        await electron.ipcRenderer.invoke(IPCEvents.SET_ALLOW_PRELOAD_OVERRIDE, !await this.get());
+    }
+};

--- a/src/electron/preload/init.ts
+++ b/src/electron/preload/init.ts
@@ -4,7 +4,7 @@ import * as IPCEvents from "@common/constants/ipcevents";
 
 export default function () {
     // Load Discord's original preload
-    const preload = process.env.DISCORD_PRELOAD;
+    const preload = process.env.BD_DISCORD_PRELOAD;
     if (preload) {
 
         // Restore original preload for future windows

--- a/src/electron/preload/patcher.ts
+++ b/src/electron/preload/patcher.ts
@@ -118,8 +118,10 @@ export default function () {
                         return newValue;
                     }
 
-                    const fakeModule = require.m.__BD_TEST__ = () => {};
-                    const isModulesProxied = fakeModule !== require.m.__BD_TEST__;
+                    const sym = Symbol.for("BetterDiscord.ModulesTest");
+
+                    const fakeModule = require.m[sym] = () => {};
+                    const isModulesProxied = fakeModule !== require.m[sym];
 
                     if (isModulesProxied) {
                         const definers: PropertyDescriptorMap = {};
@@ -131,7 +133,8 @@ export default function () {
                             definers[key] = {
                                 value: setter(require.m[key]),
                                 configurable: true,
-                                writable: true
+                                writable: true,
+                                enumerable: true
                             };
                         }
 

--- a/src/electron/preload/patcher.ts
+++ b/src/electron/preload/patcher.ts
@@ -36,9 +36,12 @@ export default function () {
             // @ts-expect-error cba
             predefine(window, chunkName, instance => {
                 instance.push([[Symbol()], {}, (require: any) => {
+                    if (!require.b) return;
+
                     require.d = (target: object, exports: any) => {
                         for (const key in exports) {
                             if (!Reflect.has(exports, key)) continue;
+                            if (Reflect.has(target, key)) continue;
 
                             try {
                                 Object.defineProperty(target, key, {
@@ -60,6 +63,7 @@ export default function () {
 
                     function setter(newValue: any) {
                         if (IS_CLASSNAME_MODULE.test(String(newValue))) {
+
                             function className(this: any, module: any, exports: any, _require: any) {
                                 if (newValue.__BD__) {
                                     newValue.__BD__.originalModule.call(this, module, exports, _require);
@@ -67,6 +71,7 @@ export default function () {
                                 else {
                                     newValue.call(this, module, exports, _require);
                                 }
+
 
                                 if (!Object.values(module.exports).every((item) => typeof item === "string")) {
                                     if (newValue.__BD__) {
@@ -113,10 +118,32 @@ export default function () {
                         return newValue;
                     }
 
-                    for (const key in require.m) {
-                        if (!Object.hasOwn(require.m, key)) continue;
+                    const fakeModule = require.m.__BD_TEST__ = () => {};
+                    const isModulesProxied = fakeModule !== require.m.__BD_TEST__;
 
-                        require.m[key] = setter(require.m[key]);
+                    if (isModulesProxied) {
+                        const definers: PropertyDescriptorMap = {};
+
+                        for (const key in require.m) {
+                            if (!Object.hasOwn(require.m, key)) continue;
+                            if (Object.hasOwn(require.c, key)) continue;
+
+                            definers[key] = {
+                                value: setter(require.m[key]),
+                                configurable: true,
+                                writable: true
+                            };
+                        }
+
+                        Object.defineProperties(require.m, definers);
+                    }
+                    else {
+                        for (const key in require.m) {
+                            if (!Object.hasOwn(require.m, key)) continue;
+                            if (Object.hasOwn(require.c, key)) continue;
+
+                            require.m[key] = setter(require.m[key]);
+                        }
                     }
 
                     require.m = new Proxy(require.m, {


### PR DESCRIPTION
Adds a warning stating that BD detected another client and for the best experience to remove the other client mod. When prompted there's a checkbox to not show again.

Additionally disables vencord from loading when BD and vencord are installed together. But triple clicking `Need support?` in the changelog will allow vencord to load