### PR TITLE
Support Discord app-* updater layouts while preserving legacy injection

### DIFF
--- a/scripts/inject.ts
+++ b/scripts/inject.ts
@@ -10,7 +10,9 @@ import copyFiles from "./helpers/copy";
 const useBdRelease = args[2] && args[2].toLowerCase() === "release";
 const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
 const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
-const bdPath = useBdRelease ? path.resolve(__dirname, "..", "dist", "betterdiscord.asar") : path.resolve(__dirname, "..", "dist");
+const distPath = path.resolve(__dirname, "..", "dist");
+const bundlePath = path.join(distPath, "betterdiscord.asar");
+const bdPath = useBdRelease ? bundlePath : distPath;
 
 function compareVersions(left: string, right: string) {
     const leftParts = left.split(".").map(part => Number.parseInt(part, 10) || 0);
@@ -90,8 +92,11 @@ const discordPath = await (async function () {
     return "";
 })();
 
-doSanityChecks(bdPath);
-buildPackage(bdPath);
+doSanityChecks(distPath);
+buildPackage(distPath);
+if (useBdRelease && !fs.existsSync(bundlePath)) {
+    throw new Error("    ❌ File missing: betterdiscord.asar. Run the dist build before using release injection.");
+}
 console.log("");
 
 console.log(`Injecting into ${release}`);
@@ -101,8 +106,14 @@ console.log(`    ✅ Found ${release} in ${discordPath}`);
 const indexJs = path.join(discordPath, "index.js");
 if (fs.existsSync(indexJs)) fs.unlinkSync(indexJs);
 if (process.env.WSL_DISTRO_NAME) {
-    copyFiles(bdPath, path.join(discordPath, "betterdiscord"));
-    fs.writeFileSync(indexJs, `require("./betterdiscord");\nmodule.exports = require("./core.asar");`);
+    if (useBdRelease) {
+        fs.copyFileSync(bundlePath, path.join(discordPath, "betterdiscord.asar"));
+        fs.writeFileSync(indexJs, `require("./betterdiscord.asar");\nmodule.exports = require("./core.asar");`);
+    }
+    else {
+        copyFiles(distPath, path.join(discordPath, "betterdiscord"));
+        fs.writeFileSync(indexJs, `require("./betterdiscord");\nmodule.exports = require("./core.asar");`);
+    }
 }
 else {
     fs.writeFileSync(indexJs, `require("${bdPath.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}");\nmodule.exports = require("./core.asar");`);

--- a/scripts/inject.ts
+++ b/scripts/inject.ts
@@ -11,33 +11,79 @@ const useBdRelease = args[2] && args[2].toLowerCase() === "release";
 const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
 const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
 const bdPath = useBdRelease ? path.resolve(__dirname, "..", "dist", "betterdiscord.asar") : path.resolve(__dirname, "..", "dist");
+
+function compareVersions(left: string, right: string) {
+    const leftParts = left.split(".").map(part => Number.parseInt(part, 10) || 0);
+    const rightParts = right.split(".").map(part => Number.parseInt(part, 10) || 0);
+    const maxLength = Math.max(leftParts.length, rightParts.length);
+
+    for (let index = 0; index < maxLength; index++) {
+        const diff = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+        if (diff !== 0) return diff;
+    }
+
+    return 0;
+}
+
+function getPreferredVersionDirectory(basedir: string) {
+    return fs.readdirSync(basedir)
+        .filter(entry => {
+            const entryPath = path.join(basedir, entry);
+            return fs.lstatSync(entryPath).isDirectory() && entry.split(".").length > 1;
+        })
+        .sort((left, right) => {
+            const leftVersion = left.startsWith("app-") ? left.slice(4) : left;
+            const rightVersion = right.startsWith("app-") ? right.slice(4) : right;
+            const versionCompare = compareVersions(rightVersion, leftVersion);
+            if (versionCompare !== 0) return versionCompare;
+
+            if (left.startsWith("app-") !== right.startsWith("app-")) {
+                return left.startsWith("app-") ? -1 : 1;
+            }
+
+            return right.localeCompare(left);
+        })[0];
+}
+
+function resolveDesktopCore(modulesPath: string) {
+    if (!fs.existsSync(modulesPath)) return "";
+
+    const wrappedCore = fs.readdirSync(modulesPath)
+        .filter(entry => entry.indexOf("discord_desktop_core-") === 0)
+        .sort()
+        .reverse()[0];
+
+    const candidates = [
+        wrappedCore && path.join(modulesPath, wrappedCore, "discord_desktop_core"),
+        path.join(modulesPath, "discord_desktop_core")
+    ].filter(Boolean) as string[];
+
+    return candidates.find(candidate => fs.existsSync(candidate)) ?? "";
+}
+
 const discordPath = await (async function () {
     let resourcePath = "";
     if (process.platform === "win32") {
         const basedir = path.join(process.env.LOCALAPPDATA!, release.replace(/ /g, ""));
         if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        // To account for discord_desktop_core-1 or any other number
-        const coreWrap = fs.readdirSync(path.join(basedir, version, "modules")).filter(e => e.indexOf("discord_desktop_core") === 0).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "modules", coreWrap, "discord_desktop_core");
+        const version = getPreferredVersionDirectory(basedir);
+        resourcePath = resolveDesktopCore(path.join(basedir, version, "modules"));
     }
     else if (process.env.WSL_DISTRO_NAME) {
         const appdata = (await bun.$`wslpath "$(cmd.exe /c "echo %LOCALAPPDATA%" 2>/dev/null | tr -d '\r')"`.text()).trim();
         const basedir = path.join(appdata, release.replace(/ /g, ""));
         if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        // To account for discord_desktop_core-1 or any other number
-        const coreWrap = fs.readdirSync(path.join(basedir, version, "modules")).filter(e => e.indexOf("discord_desktop_core") === 0).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "modules", coreWrap, "discord_desktop_core");
+        const version = getPreferredVersionDirectory(basedir);
+        resourcePath = resolveDesktopCore(path.join(basedir, version, "modules"));
     }
     else {
         let userData = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME!, ".config");
         if (process.platform === "darwin") userData = path.join(process.env.HOME!, "Library", "Application Support");
         const basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
         if (!fs.existsSync(basedir)) return "";
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
+        const version = getPreferredVersionDirectory(basedir);
         if (!version) return "";
-        resourcePath = path.join(basedir, version, "modules", "discord_desktop_core");
+        resourcePath = resolveDesktopCore(path.join(basedir, version, "modules"));
     }
 
     if (fs.existsSync(resourcePath)) return resourcePath;

--- a/scripts/inject.ts
+++ b/scripts/inject.ts
@@ -95,7 +95,7 @@ const discordPath = await (async function () {
 doSanityChecks(distPath);
 buildPackage(distPath);
 if (useBdRelease && !fs.existsSync(bundlePath)) {
-    throw new Error("    ❌ File missing: betterdiscord.asar. Run the dist build before using release injection.");
+    throw new Error("    ❌ File missing: betterdiscord.asar. Run `NODE_ENV=production bun scripts/build.ts --minify` and `bun scripts/pack.ts` before using release injection.");
 }
 console.log("");
 

--- a/src/betterdiscord/builtins/store/addonstore.ts
+++ b/src/betterdiscord/builtins/store/addonstore.ts
@@ -163,6 +163,7 @@ export default new class AddonStoreBuiltin extends Builtin {
         let protocols: string[] = [];
 
         const link = DiscordModules.LinkParser;
+        if (!link?.parse) return protocols;
 
         const includes = Array.prototype.includes;
         Array.prototype.includes = function (...args) {

--- a/src/betterdiscord/ui/base/markdown.tsx
+++ b/src/betterdiscord/ui/base/markdown.tsx
@@ -7,28 +7,28 @@ import type {ComponentClass, PropsWithChildren} from "react";
 let DiscordMarkdown: ComponentClass<PropsWithChildren<{className: string; parser: ReturnType<SimpleMarkdown["parserFor"]>; output: ReturnType<SimpleMarkdown["reactFor"]>;}>> & {rules: Rules;}, rules: Rules;
 
 function setupMarkdown() {
-    DiscordMarkdown = DiscordModules.DiscordMarkdown;
-    rules = {} as Rules;
-    if (DiscordMarkdown) {
-        rules = {
-            ...DiscordMarkdown.rules,
-            link: DiscordModules.SimpleMarkdownWrapper!.defaultRules.link
-        };
+    const markdown = DiscordModules.DiscordMarkdown;
+    if (!markdown) return;
 
-        const originalLink = rules.link?.react;
-        if (!originalLink) return;
-        rules.link.react = function (...args: any[]) {
-            const original = Reflect.apply(originalLink, undefined, args);
-            original.props.className = "bd-link";
-            original.props.target = "_blank";
-            original.props.rel = "noopener noreferrer";
-            return original;
-        };
-    }
+    DiscordMarkdown = markdown;
+    rules = {
+        ...DiscordMarkdown.rules,
+        link: DiscordModules.SimpleMarkdownWrapper!.defaultRules.link
+    };
+
+    const originalLink = rules.link?.react;
+    if (!originalLink) return;
+    rules.link.react = function (...args: any[]) {
+        const original = Reflect.apply(originalLink, undefined, args);
+        original.props.className = "bd-link";
+        original.props.target = "_blank";
+        original.props.rel = "noopener noreferrer";
+        return original;
+    };
 }
 
 export default function Markdown({className, children}: PropsWithChildren<{className?: string;}>) {
-    if (!DiscordMarkdown && !rules) setupMarkdown();
+    if (!DiscordMarkdown) setupMarkdown();
     if (!DiscordMarkdown) return <div className="bd-markdown-fallback">{children}</div>;
 
     return <DiscordMarkdown

--- a/src/betterdiscord/webpack/lazy.ts
+++ b/src/betterdiscord/webpack/lazy.ts
@@ -1,7 +1,7 @@
 import type {Webpack} from "discord";
 import {getModule} from "./searching";
 import {lazyListeners, webpackRequire} from "./require";
-import {shouldSkipModule, getDefaultKey, wrapFilter, makeException} from "./shared";
+import {shouldSkipModule, getDefaultKey, getExportedValue, wrapFilter, makeException} from "./shared";
 
 const ChunkIdRegex = /n\.e\("(\d+)"\)/g;
 const FinalModuleIdRegex = /n\.bind\(n,\s*(\d+)\s*\)/g;
@@ -42,7 +42,7 @@ export function getLazy<T>(filter: Webpack.Filter, options: Webpack.LazyOptions 
 
             for (let i = 0; i < searchKeys.length; i++) {
                 const key = searchKeys[i];
-                const exported = module.exports[key];
+                const exported = getExportedValue(module, key);
 
                 if (shouldSkipModule(exported)) continue;
 

--- a/src/betterdiscord/webpack/searching.ts
+++ b/src/betterdiscord/webpack/searching.ts
@@ -1,5 +1,5 @@
 import type {Webpack} from "discord";
-import {getDefaultKey, makeException, shouldSkipModule, wrapFilter} from "./shared";
+import {getDefaultKey, getExportedValue, makeException, shouldSkipModule, wrapFilter} from "./shared";
 import {webpackRequire} from "./require";
 import WebpackCache from "./cache";
 
@@ -21,7 +21,7 @@ export function getMatched<T>(module: Webpack.Module<any>, filter: Webpack.Filte
 
     for (let i = 0; i < searchKeys.length; i++) {
         const key = searchKeys[i];
-        const exported = module.exports[key];
+        const exported = getExportedValue(module, key);
 
         if (shouldSkipModule(exported)) continue;
 
@@ -102,7 +102,7 @@ export function getAllModules<T extends unknown[]>(filter: Webpack.Filter, optio
 
         for (let j = 0; j < searchKeys.length; j++) {
             const key = searchKeys[j];
-            const exported = module.exports[key];
+            const exported = getExportedValue(module, key);
 
             if (shouldSkipModule(exported)) continue;
 

--- a/src/betterdiscord/webpack/shared.ts
+++ b/src/betterdiscord/webpack/shared.ts
@@ -23,23 +23,42 @@ export const wrapFilter = (filter: Webpack.Filter): Webpack.Filter => Object.ass
 
 const TypedArray = Object.getPrototypeOf(Uint8Array);
 export function shouldSkipModule(exports: any) {
-    if (!(typeof exports === "object" || typeof exports === "function")) return true;
-    if (!exports) return true;
-    if (exports.TypedArray) return true;
-    if (exports === window) return true;
-    if (exports === document.documentElement) return true;
-    if (exports[Symbol.toStringTag] === "DOMTokenList") return true;
-    if (exports === Symbol) return true;
-    if (exports instanceof Window) return true;
-    if (exports instanceof TypedArray) return true;
-    if ((exports.$$loader && exports.$$baseObject) || (exports.Z?.$$loader && exports.Z?.$$baseObject)) return true;
-    return false;
+    try {
+        if (!(typeof exports === "object" || typeof exports === "function")) return true;
+        if (!exports) return true;
+        if (exports.TypedArray) return true;
+        if (exports === window) return true;
+        if (exports === document.documentElement) return true;
+        if (exports[Symbol.toStringTag] === "DOMTokenList") return true;
+        if (exports === Symbol) return true;
+        if (exports instanceof Window) return true;
+        if (exports instanceof TypedArray) return true;
+        if ((exports.$$loader && exports.$$baseObject) || (exports.Z?.$$loader && exports.Z?.$$baseObject)) return true;
+        return false;
+    }
+    catch {
+        return true;
+    }
 }
 
 export function getDefaultKey(module: Webpack.Module): Webpack.DefaultKey | undefined {
-    if ("A" in module.exports) return "A";
-    if ("Ay" in module.exports) return "Ay";
-    if (module.exports.__esModule && "default" in module.exports) return "default";
+    try {
+        if ("A" in module.exports) return "A";
+        if ("Ay" in module.exports) return "Ay";
+        if (module.exports.__esModule && "default" in module.exports) return "default";
+    }
+    catch {
+        return undefined;
+    }
+}
+
+export function getExportedValue(module: Webpack.Module, key: string) {
+    try {
+        return module.exports[key];
+    }
+    catch {
+        return undefined;
+    }
 }
 
 export const makeException = () => new Error("Module search failed!");

--- a/src/betterdiscord/webpack/utilities.ts
+++ b/src/betterdiscord/webpack/utilities.ts
@@ -3,7 +3,7 @@
 import type {Webpack} from "discord";
 import {bySource} from "./filter";
 import {getModule} from "./searching";
-import {getDefaultKey, makeException, shouldSkipModule, wrapFilter} from "./shared";
+import {getDefaultKey, getExportedValue, makeException, shouldSkipModule, wrapFilter} from "./shared";
 import {webpackRequire} from "./require";
 import WebpackCache from "./cache";
 
@@ -111,7 +111,7 @@ export function bulkGetMatched<T>(module: Webpack.Module<any>, options: Webpack.
     else if (searchDefault && (defaultKey = getDefaultKey(module))) exportKeys.push(defaultKey);
 
     for (const key of exportKeys) {
-        const exported = module.exports[key];
+        const exported = getExportedValue(module, key);
 
         if (shouldSkipModule(exported)) continue;
 

--- a/src/common/utils/memoize.ts
+++ b/src/common/utils/memoize.ts
@@ -10,8 +10,10 @@ export default function memoizeObject<T extends Record<string | number | symbol,
             if (!Object.prototype.hasOwnProperty.call(obj, mod)) return undefined;
             if (Object.getOwnPropertyDescriptor(obj, mod)?.get) {
                 const value = obj[mod];
-                delete obj[mod];
-                obj[mod as keyof typeof obj] = value;
+                if (value !== undefined) {
+                    delete obj[mod];
+                    obj[mod as keyof typeof obj] = value;
+                }
             }
             return obj[mod];
         },

--- a/src/common/utils/memoize.ts
+++ b/src/common/utils/memoize.ts
@@ -14,6 +14,7 @@ export default function memoizeObject<T extends Record<string | number | symbol,
                     delete obj[mod];
                     obj[mod as keyof typeof obj] = value;
                 }
+                return value;
             }
             return obj[mod];
         },

--- a/src/electron/preload/init.ts
+++ b/src/electron/preload/init.ts
@@ -4,14 +4,28 @@ import Module from "module";
 import {ipcRenderer as IPC} from "electron";
 import * as IPCEvents from "@common/constants/ipcevents";
 
+type ResolveFilename = (request: string, parent?: NodeJS.Module, isMain?: boolean, options?: unknown) => string;
+
 type NodeModuleResolver = typeof Module & {
-    _resolveFilename: (request: string, parent?: NodeJS.Module, isMain?: boolean, options?: unknown) => string;
+    _resolveFilename: ResolveFilename;
 };
 
-let hasPatchedDiscordModuleResolution = false;
+let restoreDiscordModuleResolution: (() => void) | undefined;
+
+function isBareDiscordNativeModule(request: string) {
+    return request.startsWith("discord_") && !request.startsWith("./") && !request.startsWith("../") && !path.isAbsolute(request) && !request.includes("/");
+}
+
+function isFromActiveDiscordVersion(parent: NodeJS.Module | undefined, activeVersionPath: string) {
+    const filename = parent?.filename;
+    if (!filename) return false;
+
+    const relativeFilename = path.relative(activeVersionPath, filename);
+    return relativeFilename !== "" && !relativeFilename.startsWith("..") && !path.isAbsolute(relativeFilename);
+}
 
 function patchDiscordModuleResolution(preload: string) {
-    if (hasPatchedDiscordModuleResolution || process.platform !== "darwin") return;
+    if (restoreDiscordModuleResolution || process.platform !== "darwin") return;
 
     const userData = process.env.DISCORD_USER_DATA;
     if (!userData) return;
@@ -22,30 +36,39 @@ function patchDiscordModuleResolution(preload: string) {
     const [versionDirectory] = relativePreload.split(path.sep);
     if (!versionDirectory?.startsWith("app-")) return;
 
-    const activeModulesPath = path.join(userData, versionDirectory, "modules");
+    const activeVersionPath = path.join(userData, versionDirectory);
+    const activeModulesPath = path.join(activeVersionPath, "modules");
     const legacyModulesPath = path.join(userData, versionDirectory.slice(4), "modules");
     if (!fs.existsSync(legacyModulesPath)) return;
 
     const nodeModule = Module as NodeModuleResolver;
-    const originalResolveFilename = nodeModule._resolveFilename.bind(nodeModule);
+    const originalResolveFilename = nodeModule._resolveFilename;
 
-    nodeModule._resolveFilename = function (request, parent, isMain, options) {
+    const patchedResolveFilename: ResolveFilename = function (request, parent, isMain, options) {
         try {
-            return originalResolveFilename(request, parent, isMain, options);
+            return originalResolveFilename.call(nodeModule, request, parent, isMain, options);
         }
         catch (error) {
-            if (!request.startsWith("discord_")) throw error;
-            if (request.startsWith("./") || request.startsWith("../") || path.isAbsolute(request) || request.includes("/")) throw error;
+            if (!isBareDiscordNativeModule(request)) throw error;
+            if (!isFromActiveDiscordVersion(parent, activeVersionPath)) throw error;
 
             const activeModulePath = path.join(activeModulesPath, request);
             const legacyModulePath = path.join(legacyModulesPath, request);
             if (fs.existsSync(activeModulePath) || !fs.existsSync(legacyModulePath)) throw error;
 
-            return originalResolveFilename(legacyModulePath, parent, isMain, options);
+            return originalResolveFilename.call(nodeModule, legacyModulePath, parent, isMain, options);
         }
     };
 
-    hasPatchedDiscordModuleResolution = true;
+    nodeModule._resolveFilename = patchedResolveFilename;
+
+    restoreDiscordModuleResolution = () => {
+        if (nodeModule._resolveFilename === patchedResolveFilename) nodeModule._resolveFilename = originalResolveFilename;
+        restoreDiscordModuleResolution = undefined;
+    };
+
+    // Keep the fallback for Discord's preload-created native module loader, but restore it when this window unloads.
+    globalThis.addEventListener?.("unload", restoreDiscordModuleResolution, {once: true});
 }
 
 export default function () {

--- a/src/electron/preload/init.ts
+++ b/src/electron/preload/init.ts
@@ -54,6 +54,7 @@ function patchDiscordModuleResolution(preload: string) {
 
             const activeModulePath = path.join(activeModulesPath, request);
             const legacyModulePath = path.join(legacyModulesPath, request);
+            // Only fall back when the active app-* tree is missing the native module but the matching legacy tree still has it.
             if (fs.existsSync(activeModulePath) || !fs.existsSync(legacyModulePath)) throw error;
 
             return originalResolveFilename.call(nodeModule, legacyModulePath, parent, isMain, options);

--- a/src/electron/preload/init.ts
+++ b/src/electron/preload/init.ts
@@ -64,6 +64,7 @@ export default function () {
             require(preload);
         }
         catch (error) {
+            // eslint-disable-next-line no-console
             console.error("BetterDiscord failed to load Discord's original preload.", error);
         }
         finally {

--- a/src/electron/preload/init.ts
+++ b/src/electron/preload/init.ts
@@ -1,6 +1,52 @@
+import fs from "fs";
+import path from "path";
+import Module from "module";
 import {ipcRenderer as IPC} from "electron";
 import * as IPCEvents from "@common/constants/ipcevents";
 
+type NodeModuleResolver = typeof Module & {
+    _resolveFilename: (request: string, parent?: NodeJS.Module, isMain?: boolean, options?: unknown) => string;
+};
+
+let hasPatchedDiscordModuleResolution = false;
+
+function patchDiscordModuleResolution(preload: string) {
+    if (hasPatchedDiscordModuleResolution || process.platform !== "darwin") return;
+
+    const userData = process.env.DISCORD_USER_DATA;
+    if (!userData) return;
+
+    const relativePreload = path.relative(userData, preload);
+    if (!relativePreload || relativePreload.startsWith("..") || path.isAbsolute(relativePreload)) return;
+
+    const [versionDirectory] = relativePreload.split(path.sep);
+    if (!versionDirectory?.startsWith("app-")) return;
+
+    const activeModulesPath = path.join(userData, versionDirectory, "modules");
+    const legacyModulesPath = path.join(userData, versionDirectory.slice(4), "modules");
+    if (!fs.existsSync(legacyModulesPath)) return;
+
+    const nodeModule = Module as NodeModuleResolver;
+    const originalResolveFilename = nodeModule._resolveFilename.bind(nodeModule);
+
+    nodeModule._resolveFilename = function (request, parent, isMain, options) {
+        try {
+            return originalResolveFilename(request, parent, isMain, options);
+        }
+        catch (error) {
+            if (!request.startsWith("discord_")) throw error;
+            if (request.startsWith("./") || request.startsWith("../") || path.isAbsolute(request) || request.includes("/")) throw error;
+
+            const activeModulePath = path.join(activeModulesPath, request);
+            const legacyModulePath = path.join(legacyModulesPath, request);
+            if (fs.existsSync(activeModulePath) || !fs.existsSync(legacyModulePath)) throw error;
+
+            return originalResolveFilename(legacyModulePath, parent, isMain, options);
+        }
+    };
+
+    hasPatchedDiscordModuleResolution = true;
+}
 
 export default function () {
     // Load Discord's original preload
@@ -10,15 +56,18 @@ export default function () {
         // Restore original preload for future windows
         IPC.send(IPCEvents.REGISTER_PRELOAD, preload);
         // Run original preload
+        patchDiscordModuleResolution(preload);
+        const originalKill = process.kill;
         try {
-            const originalKill = process.kill;
             process.kill = function (_: number, __?: string | number | undefined) {return true;};
             // eslint-disable-next-line @typescript-eslint/no-require-imports
             require(preload);
-            process.kill = originalKill;
         }
-        catch {
-            // TODO bail out
+        catch (error) {
+            console.error("BetterDiscord failed to load Discord's original preload.", error);
+        }
+        finally {
+            process.kill = originalKill;
         }
     }
 }

--- a/tests/common/utils/memoize.test.ts
+++ b/tests/common/utils/memoize.test.ts
@@ -109,4 +109,20 @@ describe("Memoize Utility", () => {
         expect(firstResult).toBe(secondResult);
         expect(count).toBe(1);
     });
+
+    test("should not memoize undefined getter results", () => {
+        let count = 0;
+        const obj = {
+            get value() {
+                count++;
+                return count > 1 ? "ready" : undefined;
+            }
+        };
+
+        const memoized = memoize(obj);
+
+        expect(memoized.value).toBeUndefined();
+        expect(memoized.value).toBe("ready");
+        expect(count).toBe(2);
+    });
 });


### PR DESCRIPTION
# Support Discord app-* updater layouts while preserving legacy injection

Base branch: `BetterDiscord/BetterDiscord:development`
Compare branch: `XxUnkn0wnxX/BetterDiscord:PR/canary-update`

Fixes https://github.com/BetterDiscord/BetterDiscord/issues/2147

## Summary

This PR updates BetterDiscord injection and startup handling for newer Discord updater layouts that create `app-*` version directories, including current Discord Canary on macOS, while preserving support for the older legacy version-directory layout.

The code in this PR was written with AI assistance and then heavily tested and checked by me before submission.

## Changes

- Prefer `app-*` version directories during manual injection when both `app-*` and legacy `0.0.*` directories exist.
- Resolve both wrapped and unwrapped `discord_desktop_core` module layouts during injection.
- Add macOS preload module-resolution fallback so `discord_*` native modules can still be loaded from the matching legacy modules directory when Discord launches from an `app-*` tree.
- Restore `process.kill` reliably after loading Discord's original preload, and log original preload failures instead of swallowing them.
- Avoid memoizing transient `undefined` getter results so Webpack module lookups can retry later during startup.
- Harden Webpack/Markdown/AddonStore lookup paths against early module access failures during Discord startup.
- Fix release injection so `dist/` validation and `dist/betterdiscord.asar` injection are handled separately for stable, PTB, and Canary.

## Review Notes

Reviewed against `upstream/development`; no blocking code-review findings found.

The PR branch intentionally does not include fork-only changes:

- no GitHub workflow edits
- no fork release/tag/default-branch changes
- no updater retargeting to the fork
- no local helper scripts
- no local `.gitignore` additions for helper scripts

## Verification

- Full test, lint, build, and asar packaging passed on my GitHub fork via Actions.
- `bun test tests/common/utils/memoize.test.ts`
- `NODE_ENV=production BRANCH_NAME=PR/canary-update COMMIT_HASH=$(git rev-parse --short HEAD) bun scripts/build.ts --minify`
- `bun scripts/pack.ts`

Local focused regression testing and production packaging also pass.
