### PR TITLE
Fix themes with special characters in names not properly being cleaned up

### DIFF
--- a/src/betterdiscord/modules/dommanager.ts
+++ b/src/betterdiscord/modules/dommanager.ts
@@ -116,13 +116,13 @@ export default class DOMManager {
 
     static removeTheme(id: string) {
         id = this.escapeID(id);
-        const exists = this.getElement(`#${id}`, this.bdThemes);
+        const exists = document.getElementById(id);
         if (exists) exists.remove();
     }
 
     static injectTheme(id: string, css: string) {
         id = this.escapeID(id);
-        const style = this.getElement(`#${id}`, this.bdThemes) || this.createElement("style", {id});
+        const style = document.getElementById(id) || this.createElement("style", {id});
         style.textContent = css;
         this.bdThemes.append(style);
     }


### PR DESCRIPTION
Right now themes with parentheses, leading numbers, or other special characters don't properly get cleaned up and instead get duplicated whenever they are reloaded.

This seems to be due to some jank with querySelector. Let's say there's the following element: `<div id="thing-\(real\)"></div>`. Running `document.querySelector("#thing-\\(real\\)")` returns nothing, while doing `document.getElementById("thing-\\(real\\)")` works fine. This can be worked around by doing `document.querySelector("[id='thing-\\\\(real\\\\)']")`, for some reason.

This PR makes dommanager use getElementById over querySelector for finding existing themes, avoiding this issue.