### PR TITLE
properly account for context menus in crash recovery

### DIFF
--- a/src/betterdiscord/builtins/developer/recovery.tsx
+++ b/src/betterdiscord/builtins/developer/recovery.tsx
@@ -32,6 +32,10 @@ async function attemptRecovery() {
             errorMessage: "Failed to pop all modals"
         },
         {
+            action: () => Dispatcher?.dispatch({type: "CONTEXT_MENU_CLOSE"}),
+            errorMessage: "Failed to close context menus"
+        },
+        {
             action: () => transitionTo?.("/channels/@me"),
             errorMessage: "Failed to route to main channel"
         },


### PR DESCRIPTION
If a user crashes from a context menu, recovery can now properly close the menus instead of the client becoming hard-crashed