### PR TITLE
Blacklist ZLIB

### DIFF
--- a/assets/locales/en-us.json
+++ b/assets/locales/en-us.json
@@ -339,7 +339,9 @@
                 "one": "One theme has been enabled.",
                 "other": "{{count}} themes have been enabled."
             }
-        }
+        },
+        "blacklistedPlugin": "Blacklisted Plugin",
+        "blacklistedPluginStack": "{{name}} interferes with BetterDiscord and can cause instability, crashing, and incompatibility with other plugins"
     },
     "CustomCSS": {
         "confirmationText": "You have unsaved changes to your Custom CSS. Closing this window will lose all those changes.",

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -88,7 +88,36 @@ export default new class PluginManager extends AddonManager<Plugin> {
         }
     }
 
+    private blacklist: Array<[filename: string, name: string, fileContentMatch?: string | RegExp]> = [
+        // Breaks the declaration API and this causes damage to BD and other plugins
+        [
+            "0PluginLibrary.plugin.js",
+            "ZeresPluginLibrary",
+            /(\()?(?:self|globalThis|global|window)\1\s*(?:\.ZeresPluginLibrary|\[\s*(["'])ZeresPluginLibrary\2\s*\])\s*=/
+        ]
+    ];
+
     initAddon(addon: Addon) {
+        if (this.blacklist.some(
+            ([filename, name, fileContentMatch]) => {
+                if (addon.filename === filename) return true;
+                if (addon.name === name) return true;
+                if (fileContentMatch && addon.fileContent) {
+                    if (typeof fileContentMatch === "string" && addon.fileContent.includes(fileContentMatch)) return true;
+                    if (fileContentMatch instanceof RegExp && fileContentMatch.test(addon.fileContent)) return true;
+                }
+
+                return false;
+            }
+        )) {
+            this.showAddonError(addon, t("Addons.blacklistedPlugin"), {
+                message: "",
+                stack: t("Addons.blacklistedPluginStack", {name: addon.name || addon.filename})
+            });
+
+            return null;
+        }
+
         const plugin = this.runPlugin(addon);
         if (!plugin) return null;
 

--- a/src/betterdiscord/stores/addonerrors.ts
+++ b/src/betterdiscord/stores/addonerrors.ts
@@ -2,22 +2,22 @@ import type AddonError from "@structs/addonerror";
 import Store from "./base";
 
 export default new class AddonErrorsStore extends Store {
-    pluginErrors: AddonError[] = [];
-    themeErrors: AddonError[] = [];
+    pluginErrors: Record<string, AddonError> = {};
+    themeErrors: Record<string, AddonError> = {};
 
     addPluginError(error: AddonError) {
-        this.pluginErrors.push(error);
+        this.pluginErrors[error.file] = error;
         this.emitChange();
     }
 
     addThemeError(error: AddonError) {
-        this.themeErrors.push(error);
+        this.themeErrors[error.file] = error;
         this.emitChange();
     }
 
     clearErrors() {
-        this.pluginErrors = [];
-        this.themeErrors = [];
+        this.pluginErrors = {};
+        this.themeErrors = {};
         this.emitChange();
     }
 };

--- a/src/betterdiscord/ui/modals/addonerrormodal.tsx
+++ b/src/betterdiscord/ui/modals/addonerrormodal.tsx
@@ -71,8 +71,8 @@ export interface AddonErrorModalProps {
  * @returns
  */
 export default function AddonErrorModal({transitionState, onClose}: AddonErrorModalProps) {
-    const pluginErrors = useStateFromStores(AddonErrorsStore, () => [...AddonErrorsStore.pluginErrors]);
-    const themeErrors = useStateFromStores(AddonErrorsStore, () => [...AddonErrorsStore.themeErrors]);
+    const pluginErrors = useStateFromStores(AddonErrorsStore, () => Object.values(AddonErrorsStore.pluginErrors), [], true);
+    const themeErrors = useStateFromStores(AddonErrorsStore, () => Object.values(AddonErrorsStore.themeErrors), [], true);
 
     const tabs = useMemo<Array<ReturnType<typeof generateTab>>>(() => {
         return [


### PR DESCRIPTION
Disable ZLIB from loading, as it breaks the declaration API

Additionally the plugin blacklisting api is easily extendable