### PR TITLE
fix(inject): support Discord 1.0.136+ app-<ver>/<wrapper>/ module layout

### DIFF
--- a/scripts/inject.ts
+++ b/scripts/inject.ts
@@ -11,37 +11,77 @@ const useBdRelease = args[2] && args[2].toLowerCase() === "release";
 const releaseInput = useBdRelease ? args[3] && args[3].toLowerCase() : args[2] && args[2].toLowerCase();
 const release = releaseInput === "canary" ? "Discord Canary" : releaseInput === "ptb" ? "Discord PTB" : "Discord";
 const bdPath = useBdRelease ? path.resolve(__dirname, "..", "dist", "betterdiscord.asar") : path.resolve(__dirname, "..", "dist");
+// Discord 1.0.136+ writes to `app-<X>.<Y>.<Z>` and may leave an empty legacy
+// `<X>.<Y>.<Z>` alongside it; prefer `app-*`, then highest version, and prefer
+// entries that actually contain a `modules/` subdir.
+function pickVersionDir(basedir: string): string | undefined {
+    const entries = fs.readdirSync(basedir).filter(name => {
+        try {return fs.lstatSync(path.join(basedir, name)).isDirectory();}
+        catch {return false;}
+    });
+    const versionRe = /^(app-)?(\d+)\.(\d+)\.(\d+)$/;
+    const candidates = entries
+        .map(name => ({name, m: name.match(versionRe)}))
+        .filter((c): c is {name: string; m: RegExpMatchArray} => Boolean(c.m))
+        .map(c => ({
+            name: c.name,
+            isApp: Boolean(c.m[1]),
+            tuple: [+c.m[2], +c.m[3], +c.m[4]] as [number, number, number],
+        }));
+    if (!candidates.length) return undefined;
+    candidates.sort((a, b) => {
+        if (a.isApp !== b.isApp) return a.isApp ? -1 : 1;
+        for (let i = 0; i < 3; i++) {
+            if (a.tuple[i] !== b.tuple[i]) return b.tuple[i] - a.tuple[i];
+        }
+        return 0;
+    });
+    const usable = candidates.find(c => fs.existsSync(path.join(basedir, c.name, "modules")));
+    return (usable ?? candidates[0]).name;
+}
+
+// Tries the new wrapped layout (`discord_desktop_core-<N>/discord_desktop_core`)
+// first, falls back to the legacy unwrapped layout (`discord_desktop_core`).
+function resolveCorePath(modulesDir: string): string {
+    if (!fs.existsSync(modulesDir)) return "";
+    const wrappers = fs.readdirSync(modulesDir)
+        .map(name => {
+            const m = name.match(/^discord_desktop_core-(\d+)$/);
+            return m ? {name, n: +m[1]} : null;
+        })
+        .filter((w): w is {name: string; n: number} => w !== null)
+        .sort((a, b) => b.n - a.n);
+    for (const {name} of wrappers) {
+        const candidate = path.join(modulesDir, name, "discord_desktop_core");
+        if (fs.existsSync(candidate)) return candidate;
+    }
+    const legacy = path.join(modulesDir, "discord_desktop_core");
+    if (fs.existsSync(legacy)) return legacy;
+    return "";
+}
+
 const discordPath = await (async function () {
-    let resourcePath = "";
+    let basedir = "";
     if (process.platform === "win32") {
-        const basedir = path.join(process.env.LOCALAPPDATA!, release.replace(/ /g, ""));
-        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        // To account for discord_desktop_core-1 or any other number
-        const coreWrap = fs.readdirSync(path.join(basedir, version, "modules")).filter(e => e.indexOf("discord_desktop_core") === 0).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "modules", coreWrap, "discord_desktop_core");
+        basedir = path.join(process.env.LOCALAPPDATA!, release.replace(/ /g, ""));
     }
     else if (process.env.WSL_DISTRO_NAME) {
         const appdata = (await bun.$`wslpath "$(cmd.exe /c "echo %LOCALAPPDATA%" 2>/dev/null | tr -d '\r')"`.text()).trim();
-        const basedir = path.join(appdata, release.replace(/ /g, ""));
-        if (!fs.existsSync(basedir)) throw new Error(`Cannot find directory for ${release}`);
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        // To account for discord_desktop_core-1 or any other number
-        const coreWrap = fs.readdirSync(path.join(basedir, version, "modules")).filter(e => e.indexOf("discord_desktop_core") === 0).sort().reverse()[0];
-        resourcePath = path.join(basedir, version, "modules", coreWrap, "discord_desktop_core");
+        basedir = path.join(appdata, release.replace(/ /g, ""));
     }
     else {
         let userData = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME!, ".config");
         if (process.platform === "darwin") userData = path.join(process.env.HOME!, "Library", "Application Support");
-        const basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
-        if (!fs.existsSync(basedir)) return "";
-        const version = fs.readdirSync(basedir).filter(f => fs.lstatSync(path.join(basedir, f)).isDirectory() && f.split(".").length > 1).sort().reverse()[0];
-        if (!version) return "";
-        resourcePath = path.join(basedir, version, "modules", "discord_desktop_core");
+        basedir = path.join(userData, release.toLowerCase().replace(" ", ""));
     }
 
-    if (fs.existsSync(resourcePath)) return resourcePath;
-    return "";
+    if (!fs.existsSync(basedir)) throw new Error(`No ${release} install at ${basedir}`);
+    const version = pickVersionDir(basedir);
+    if (!version) throw new Error(`No version dir in ${basedir} (expected app-X.Y.Z or X.Y.Z)`);
+    const modulesDir = path.join(basedir, version, "modules");
+    const core = resolveCorePath(modulesDir);
+    if (!core) throw new Error(`Found ${modulesDir} but no discord_desktop_core (tried wrapped discord_desktop_core-N/ and legacy)`);
+    return core;
 })();
 
 doSanityChecks(bdPath);
@@ -49,7 +89,6 @@ buildPackage(bdPath);
 console.log("");
 
 console.log(`Injecting into ${release}`);
-if (!fs.existsSync(discordPath)) throw new Error(`Cannot find directory for ${release}`);
 console.log(`    ✅ Found ${release} in ${discordPath}`);
 
 const indexJs = path.join(discordPath, "index.js");


### PR DESCRIPTION
Discord 1.0.136 switched its Linux/macOS module path

* from `~/.config/discord/<ver>/modules/discord_desktop_core/`
* to `~/.config/discord/app-<ver>/modules/discord_desktop_core-<N>/discord_desktop_core/`

Which may leave an empty legacy `<ver>/` directory alongside the new `app-<ver>/` one. The injector's Linux/macOS branch unconditionally appended `modules/discord_desktop_core` and didn't know about the `discord_desktop_core-<N>` wrapper, so injection failed with "Cannot find directory for Discord". Windows/WSL handled the wrapper but had no fallback for the legacy unwrapped layout.

Refactor the resolver into two helpers shared across all platforms:

- pickVersionDir: matches `^(app-)?\d+\.\d+\.\d+$`, prefers `app-*`, then highest version, then entries whose `modules/` actually exists (so an empty legacy stub left by the new updater is skipped).
- resolveCorePath: tries the wrapped `discord_desktop_core-<N>/ discord_desktop_core` form first, falls back to the legacy unwrapped `discord_desktop_core` form.

This fixes injection on current Linux Discord and adds legacy-layout fallback to the Windows/WSL paths for free.

Fixes #2170

Caveats / decisions worth noting in the PR body but not the subject:

- Windows and WSL behavior expands slightly (now also accepts legacy <ver>/modules/discord_desktop_core/). Strictly more compatible.
- The macOS preload native-module fallback PR #2148 attempted is a separate concern and out of scope here.