### PR TITLE
getProxy & Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "api": "bun run --bun jsdoc -X -r renderer/src/modules/api/ > dist/jsdoc-ast.json",
         "translations": "bun -r dotenv/config scripts/translations.js",
         "circulars": "bun run --bun dpdm -T --no-warning --no-tree src/betterdiscord/index.js",
-        "typecheck": "tsc"
+        "typecheck": "tsc",
+        "generate-types": "bun scripts/types"
     },
     "devDependencies": {
         "@electron/asar": "^3.2.0",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -41,7 +41,7 @@ async function buildTypes() {
         .replaceAll("\ndeclare ", "\n")
         .replace(/\nexport .+\n/, "");
 
-    const insertAt = content.indexOf("\n", content.lastIndexOf("import")) + 2;
+    const insertAt = content.indexOf("\n", content.lastIndexOf("import")) + 1;
     const namespaces = "declare global {\nnamespace BetterDiscord {\n";
     const declaration = "\n\nconst BdApi: typeof BetterDiscord.BdApi;\ninterface Window {\n    BdApi: typeof BetterDiscord.BdApi;\n}";
     const header = "export {};\n\n";

--- a/src/betterdiscord/api/utils.ts
+++ b/src/betterdiscord/api/utils.ts
@@ -4,6 +4,7 @@ import {debounce, extend, findInTree, getNestedProp} from "@common/utils";
 import {forceLoad} from "@webpack";
 import Store from "@stores/base";
 import {mapObject} from "@utils/object";
+import cache from "@common/utils/cache";
 
 
 /**
@@ -104,9 +105,33 @@ const Utils = {
     /**
      * A class which can be listened to for changes
      */
-    Store
+    Store,
+
+    /**
+     * A simple utility for caching a result
+     *
+     * @example
+     * const foo = cache(() => console.log("Called"));
+     *
+     * foo(); // LOG: Called
+     * foo(); // No log
+     */
+    cache: Object.assign(<T>(factory: () => T) => cache<T>(factory), {
+        /**
+         * Like {@link Utils.cache} but factory runs when its accessed instead of manually calling it
+         *
+         * @example
+         * const foo = cache.proxy(() => console.log("Called")); // no log
+         *
+         * foo.bar // LOG: Called
+         * foo.bar // No log
+         */
+
+        proxy: <T extends object>(factory: () => T, typeofIsObject?: boolean, CALL_LIMIT?: number) => cache.proxy<T>(factory, typeofIsObject, CALL_LIMIT)
+    })
 } as const;
 
 Object.freeze(Utils);
+Object.freeze(Utils.cache);
 
 export default Utils;

--- a/src/betterdiscord/api/webpack.ts
+++ b/src/betterdiscord/api/webpack.ts
@@ -1,6 +1,6 @@
-import type {Options, ModuleFilter, MangledOptions, WithKeyOptions, ExportedOnlyFilter, BulkQueries, LazyOptions} from "@typed/discord/webpack";
+import type {Options, ModuleFilter, MangledOptions, WithKeyOptions, ExportedOnlyFilter, BulkQueries, LazyOptions, ProxyOptions} from "@typed/discord/webpack";
 import Logger from "@common/logger";
-import {Filters, getAllModules, getBulk, getBulkKeyed, getById, getLazy, getMangled, getModule, getStore, getWithKey, modules, Stores} from "@webpack";
+import {Filters, getAllModules, getBulk, getBulkKeyed, getBulkKeyedProxy, getBulkProxy, getById, getLazy, getMangled, getMangledProxy, getModule, getProxy, getStore, getWithKey, modules, Stores} from "@webpack";
 import ReactUtils from "./reactutils";
 
 type WithOptions<T, B extends WebpackOptions> = [...T[], B] | T[];
@@ -182,6 +182,27 @@ const Webpack = {
         if (("fatal" in options) && typeof (options.fatal) !== "boolean") return Logger.error("BdApi.Webpack~getById", "Invalid type for options.fatal", options.fatal, "Expected: boolean");
 
         return getById(id, options);
+    },
+
+    getProxy<T extends object>(filter: ModuleFilter, options: ProxyOptions = {}) {
+        if (("defaultExport" in options) && typeof (options.defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getProxy", "Invalid type for options.defaultExport", options.defaultExport, "Expected: boolean");
+        if (("searchExports" in options) && typeof (options.searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getProxy", "Invalid type for options.searchExports", options.searchExports, "Expected: boolean");
+        if (("raw" in options) && typeof (options.raw) !== "boolean") return Logger.error("BdApi.Webpack~getProxy", "Invalid type for options.raw", options.raw, "Expected: boolean");
+        if (("fatal" in options) && typeof (options.fatal) !== "boolean") return Logger.error("BdApi.Webpack~getProxy", "Invalid type for options.fatal", options.fatal, "Expected: boolean");
+
+        return getProxy<T>(filter, options);
+    },
+
+    getBulkProxy<T extends any[]>(...queries: BulkQueries[]) {return getBulkProxy<T>(...queries);},
+    getBulkKeyedProxy<T extends object>(queries: Record<keyof T, BulkQueries>) {return getBulkKeyedProxy<T>(queries);},
+
+    getMangledProxy<T extends object>(filter: ModuleFilter | string | RegExp, mangled: Record<keyof T, ExportedOnlyFilter>, options: MangledOptions = {}) {
+        const {defaultExport = false, searchExports = false, raw = false, fatal = false} = options;
+        if (typeof (defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getMangledProxy", "Invalid type for options.defaultExport", defaultExport, "Expected: boolean");
+        if (typeof (searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getMangledProxy", "Invalid type for options.searchExports", searchExports, "Expected: boolean");
+        if (typeof (raw) !== "boolean") return Logger.error("BdApi.Webpack~getMangledProxy", "Invalid type for options.raw", raw, "Expected: boolean");
+        if (typeof (fatal) !== "boolean") return Logger.error("BdApi.Webpack~getMangledProxy", "Invalid type for options.fatal", fatal, "Expected: boolean");
+        return getMangledProxy<T>(filter, mangled, options);
     }
 };
 

--- a/src/betterdiscord/api/webpack.ts
+++ b/src/betterdiscord/api/webpack.ts
@@ -1,4 +1,4 @@
-import type {Options, ModuleFilter, MangledOptions, WithKeyOptions, ExportedOnlyFilter, BulkQueries, LazyOptions, ProxyOptions} from "@typed/discord/webpack";
+import type {Options, ModuleFilter, MangledOptions, WithKeyOptions, ExportedOnlyFilter, BulkQueries, LazyOptions, ProxyOptions, ProxyBulkQueries} from "@typed/discord/webpack";
 import Logger from "@common/logger";
 import {Filters, getAllModules, getBulk, getBulkKeyed, getBulkKeyedProxy, getBulkProxy, getById, getLazy, getMangled, getMangledProxy, getModule, getProxy, getStore, getWithKey, modules, Stores} from "@webpack";
 import ReactUtils from "./reactutils";
@@ -121,7 +121,7 @@ const Webpack = {
         return Webpack.getModule<T>(Filters.byRegex(regex), Object.assign({}, options, {first: false}));
     },
 
-    getMangled<T extends object>(filter: ModuleFilter | string | RegExp, mangled: Record<keyof T, ExportedOnlyFilter>, options: MangledOptions = {}) {
+    getMangled<T extends object>(filter: ModuleFilter | string | RegExp | Array<string | RegExp> | number, mangled: Record<keyof T, ExportedOnlyFilter>, options: MangledOptions = {}) {
         const {defaultExport = false, searchExports = false, raw = false, fatal = false} = options;
         if (typeof (defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getMangled", "Invalid type for options.defaultExport", defaultExport, "Expected: boolean");
         if (typeof (searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getMangled", "Invalid type for options.searchExports", searchExports, "Expected: boolean");
@@ -193,10 +193,10 @@ const Webpack = {
         return getProxy<T>(filter, options);
     },
 
-    getBulkProxy<T extends any[]>(...queries: BulkQueries[]) {return getBulkProxy<T>(...queries);},
-    getBulkKeyedProxy<T extends object>(queries: Record<keyof T, BulkQueries>) {return getBulkKeyedProxy<T>(queries);},
+    getBulkProxy<T extends any[]>(...queries: ProxyBulkQueries[]) {return getBulkProxy<T>(...queries);},
+    getBulkKeyedProxy<T extends object>(queries: Record<keyof T, ProxyBulkQueries>) {return getBulkKeyedProxy<T>(queries);},
 
-    getMangledProxy<T extends object>(filter: ModuleFilter | string | RegExp, mangled: Record<keyof T, ExportedOnlyFilter>, options: MangledOptions = {}) {
+    getMangledProxy<T extends object>(filter: ModuleFilter | string | RegExp | Array<string | RegExp> | number, mangled: Record<keyof T, ExportedOnlyFilter>, options: MangledOptions = {}) {
         const {defaultExport = false, searchExports = false, raw = false, fatal = false} = options;
         if (typeof (defaultExport) !== "boolean") return Logger.error("BdApi.Webpack~getMangledProxy", "Invalid type for options.defaultExport", defaultExport, "Expected: boolean");
         if (typeof (searchExports) !== "boolean") return Logger.error("BdApi.Webpack~getMangledProxy", "Invalid type for options.searchExports", searchExports, "Expected: boolean");

--- a/src/betterdiscord/api/webpack.ts
+++ b/src/betterdiscord/api/webpack.ts
@@ -1,6 +1,6 @@
-import type {Options, ModuleFilter, MangledOptions, WithKeyOptions, ExportedOnlyFilter, BulkQueries, LazyOptions, ProxyOptions, ProxyBulkQueries} from "@typed/discord/webpack";
+import type {Options, ModuleFilter, MangledOptions, WithKeyOptions, ExportedOnlyFilter, BulkQueries, LazyOptions, ProxyOptions} from "@typed/discord/webpack";
 import Logger from "@common/logger";
-import {Filters, getAllModules, getBulk, getBulkKeyed, getBulkKeyedProxy, getBulkProxy, getById, getLazy, getMangled, getMangledProxy, getModule, getProxy, getStore, getWithKey, modules, Stores} from "@webpack";
+import {Filters, getAllModules, getBulk, getBulkKeyed, getById, getLazy, getMangled, getMangledProxy, getModule, getProxy, getStore, getWithKey, modules, Stores} from "@webpack";
 import ReactUtils from "./reactutils";
 
 type WithOptions<T, B extends WebpackOptions> = [...T[], B] | T[];
@@ -192,9 +192,6 @@ const Webpack = {
 
         return getProxy<T>(filter, options);
     },
-
-    getBulkProxy<T extends any[]>(...queries: ProxyBulkQueries[]) {return getBulkProxy<T>(...queries);},
-    getBulkKeyedProxy<T extends object>(queries: Record<keyof T, ProxyBulkQueries>) {return getBulkKeyedProxy<T>(queries);},
 
     getMangledProxy<T extends object>(filter: ModuleFilter | string | RegExp | Array<string | RegExp> | number, mangled: Record<keyof T, ExportedOnlyFilter>, options: MangledOptions = {}) {
         const {defaultExport = false, searchExports = false, raw = false, fatal = false} = options;

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -59,7 +59,7 @@ export default new class PluginManager extends AddonManager<Plugin> {
         Logger.log("PluginManager", `Loading addons at point: ${point}`);
 
         for (const addon of this.addonList) {
-            if (addon.runAt !== point || !this.state[addon.id]) continue;
+            if (addon.runAt !== point || !(this.state[addon.id] || addon.filename === "0BDFDB.plugin.js")) continue;
             this.startAddon(addon);
         }
 
@@ -71,7 +71,7 @@ export default new class PluginManager extends AddonManager<Plugin> {
         try {
             const module = {filename: plugin.filename, exports: {}};
 
-            plugin.fileContent += normalizeExports + `\n//# sourceURL=betterdiscord://plugins/${plugin.filename}`;
+            plugin.fileContent += normalizeExports + `\n//# sourceURL=betterdiscord://betterdiscord/plugins/${plugin.filename}`;
 
             // Wrap the plugin in a function and run it
             const wrappedPlugin = new Function("require", "module", "exports", "__filename", "__dirname", plugin.fileContent!); // eslint-disable-line no-new-func

--- a/src/betterdiscord/types/discord/webpack.ts
+++ b/src/betterdiscord/types/discord/webpack.ts
@@ -77,11 +77,6 @@ export type BulkQueries = Options & {
     mapDeclarations?: boolean;
 };
 
-export type ProxyBulkQueries = Omit<BulkQueries, "fatal"> & {
-    /** Makes the proxy be an object when `true` sometimes needed for react components */
-    typeofIsObject?: boolean;
-};
-
 export type WithKeyOptions = Options & {
     /** The module to find the key on */
     target?: any;

--- a/src/betterdiscord/types/discord/webpack.ts
+++ b/src/betterdiscord/types/discord/webpack.ts
@@ -51,6 +51,11 @@ export type LazyOptions = Options & {
     signal?: AbortSignal;
 };
 
+export type ProxyOptions = Options & {
+    /** Makes the proxy be an object when `true` sometimes needed for react components */
+    typeofIsObject?: boolean;
+};
+
 export type MangledOptions = Omit<Options, "declarationFilter"> & {
     /** Whether to map declarations instead of exports */
     mapDeclarations?: boolean;
@@ -71,6 +76,12 @@ export type BulkQueries = Options & {
     /** Whether the mapper should apply to the module's declarations instead of exports */
     mapDeclarations?: boolean;
 };
+
+export type ProxyBulkQueries = BulkQueries & {
+    /** Makes the proxy be an object when `true` sometimes needed for react components */
+    typeofIsObject?: boolean;
+};
+
 export type WithKeyOptions = Options & {
     /** The module to find the key on */
     target?: any;

--- a/src/betterdiscord/types/discord/webpack.ts
+++ b/src/betterdiscord/types/discord/webpack.ts
@@ -51,7 +51,7 @@ export type LazyOptions = Options & {
     signal?: AbortSignal;
 };
 
-export type ProxyOptions = Options & {
+export type ProxyOptions = Omit<Options, "fatal"> & {
     /** Makes the proxy be an object when `true` sometimes needed for react components */
     typeofIsObject?: boolean;
 };
@@ -77,7 +77,7 @@ export type BulkQueries = Options & {
     mapDeclarations?: boolean;
 };
 
-export type ProxyBulkQueries = BulkQueries & {
+export type ProxyBulkQueries = Omit<BulkQueries, "fatal"> & {
     /** Makes the proxy be an object when `true` sometimes needed for react components */
     typeofIsObject?: boolean;
 };

--- a/src/betterdiscord/webpack/utilities.ts
+++ b/src/betterdiscord/webpack/utilities.ts
@@ -237,17 +237,17 @@ export function getBulkKeyed<T extends object>(queries: Record<keyof T, Webpack.
 }
 
 export function getProxy<T extends object>(filter: Webpack.ModuleFilter, options: Webpack.ProxyOptions = {}): T {
-    return cache.proxy(() => getModule<T>(filter, options)!, options.typeofIsObject);
+    return cache.proxy(() => getModule<T>(filter, {...options, fatal: true})!, options.typeofIsObject);
 }
 
 export function getBulkProxy<T extends any[]>(...queries: Webpack.ProxyBulkQueries[]): T {
-    const cached = cache(() => getBulk(...queries));
+    const cached = cache(() => getBulk(...queries.map(x => ({...x, fatal: true}))));
 
     return queries.map((query, index) => cache.proxy(() => cached()[index], query.typeofIsObject)) as T;
 }
 
 export function getBulkKeyedProxy<T extends object>(queries: Record<keyof T, Webpack.ProxyBulkQueries>): T {
-    const modules = cache(() => getBulk(...Object.values(queries) as Webpack.ProxyBulkQueries[]));
+    const modules = cache(() => getBulk(...Object.values(queries).map(x => ({...(x as Webpack.ProxyBulkQueries), fatal: true}))));
 
     return Object.fromEntries(
         Object.entries(queries).map(([key, query], index) => [key, cache.proxy(() => modules()[index], (query as Webpack.ProxyBulkQueries).typeofIsObject)])
@@ -259,5 +259,5 @@ export function getMangledProxy<T extends object>(
     mappers: Record<keyof T, Webpack.ExportedOnlyFilter>,
     options: Webpack.MangledOptions = {}
 ): T {
-    return cache.proxy(() => getMangled<T>(filter, mappers, options));
+    return cache.proxy(() => getMangled<T>(filter, mappers, {...options, fatal: true}));
 }

--- a/src/betterdiscord/webpack/utilities.ts
+++ b/src/betterdiscord/webpack/utilities.ts
@@ -240,20 +240,6 @@ export function getProxy<T extends object>(filter: Webpack.ModuleFilter, options
     return cache.proxy(() => getModule<T>(filter, {...options, fatal: true})!, options.typeofIsObject);
 }
 
-export function getBulkProxy<T extends any[]>(...queries: Webpack.ProxyBulkQueries[]): T {
-    const cached = cache(() => getBulk(...queries.map(x => ({...x, fatal: true}))));
-
-    return queries.map((query, index) => cache.proxy(() => cached()[index], query.typeofIsObject)) as T;
-}
-
-export function getBulkKeyedProxy<T extends object>(queries: Record<keyof T, Webpack.ProxyBulkQueries>): T {
-    const modules = cache(() => getBulk(...Object.values(queries).map(x => ({...(x as Webpack.ProxyBulkQueries), fatal: true}))));
-
-    return Object.fromEntries(
-        Object.entries(queries).map(([key, query], index) => [key, cache.proxy(() => modules()[index], (query as Webpack.ProxyBulkQueries).typeofIsObject)])
-    ) as T;
-}
-
 export function getMangledProxy<T extends object>(
     filter: Webpack.ModuleFilter | string | RegExp | Array<string | RegExp> | number,
     mappers: Record<keyof T, Webpack.ExportedOnlyFilter>,

--- a/src/betterdiscord/webpack/utilities.ts
+++ b/src/betterdiscord/webpack/utilities.ts
@@ -8,6 +8,7 @@ import {webpackRequire} from "./require";
 import WebpackCache from "./cache";
 import {mapObject} from "@utils/object";
 import {getLazy} from "./lazy";
+import cache from "@common/utils/cache";
 
 export function* getWithKey(filter: Webpack.ExportedOnlyFilter, {target = null, ...rest}: Webpack.WithKeyOptions = {}) {
     yield target ??= getModule(exports =>
@@ -233,4 +234,30 @@ export function getBulkKeyed<T extends object>(queries: Record<keyof T, Webpack.
     return Object.fromEntries(
         Object.keys(queries).map((key, index) => [key, modules[index]])
     ) as T;
+}
+
+export function getProxy<T extends object>(filter: Webpack.ModuleFilter, options: Webpack.ProxyOptions = {}): T {
+    return cache.proxy(() => getModule<T>(filter, options)!, options.typeofIsObject);
+}
+
+export function getBulkProxy<T extends any[]>(...queries: Webpack.ProxyBulkQueries[]): T {
+    const cached = cache(() => getBulk(...queries));
+
+    return queries.map((query, index) => cache.proxy(() => cached()[index], query.typeofIsObject)) as T;
+}
+
+export function getBulkKeyedProxy<T extends object>(queries: Record<keyof T, Webpack.ProxyBulkQueries>): T {
+    const modules = cache(() => getBulk(...Object.values(queries) as Webpack.ProxyBulkQueries[]));
+
+    return Object.fromEntries(
+        Object.entries(queries).map(([key, query], index) => [key, cache.proxy(() => modules()[index], (query as Webpack.ProxyBulkQueries).typeofIsObject)])
+    ) as T;
+}
+
+export function getMangledProxy<T extends object>(
+    filter: Webpack.ModuleFilter | string | RegExp | Array<string | RegExp> | number,
+    mappers: Record<keyof T, Webpack.ExportedOnlyFilter>,
+    options: Webpack.MangledOptions = {}
+): T {
+    return cache.proxy(() => getMangled<T>(filter, mappers, options));
 }

--- a/src/common/utils/cache.ts
+++ b/src/common/utils/cache.ts
@@ -1,0 +1,134 @@
+export interface Cache<T> {
+    /**
+     * Calls the factory function
+     * If only the value hasn't been set or if the call count is over
+     */
+    (): T,
+    /**
+     * Just a getter form of accessing the data
+     */
+    readonly get: T,
+    /**
+     * Checks to see if a value has been cached
+     */
+    hasValue(): boolean,
+    /**
+     * Completly resets the cache factory
+     *
+     * @example
+     * const foo = cache(() => console.log("Called"));
+     *
+     * foo(); // LOG: Called
+     * foo(); // No log
+     *
+     * foo.reset();
+     *
+     * foo(); // LOG: Called
+     * foo(); // No log
+     */
+    reset(): void,
+    /**
+     * Sets the call limit until it resets
+     *
+     * @example
+     * const foo = cache(() => console.log("Called"));
+     * foo.CALL_LIMIT = 2;
+     *
+     * foo(); // LOG: Called
+     * foo(); // No log
+     * foo(); // LOG: Called
+     */
+    CALL_LIMIT: number;
+}
+
+export default function cache<T>(factory: () => T): Cache<T> {
+    const value = {count: 0} as {current: T, count: number;} | {count: number;};
+
+    const cacher: Cache<T> = () => {
+        if (value.count++ > (limit - 1)) cacher.reset();
+        if ("current" in value) return value.current;
+
+        const current = factory();
+        (value as {current: T, count: number;}).current = current;
+
+        return current;
+    };
+
+    cacher.hasValue = () => "current" in value;
+
+    cacher.reset = () => {
+        // @ts-expect-error Types are annoying
+        if ("current" in value) delete value.current;
+        value.count = 0;
+    };
+
+    let limit = Infinity;
+    cacher.CALL_LIMIT = limit;
+    Object.defineProperty(cacher, "CALL_LIMIT", {
+        get: () => limit,
+        set: (v) => {
+            if (typeof v !== "number" || isNaN(v) || v <= 0 || Math.round(v) !== v) {
+                throw new Error("Unable to set max call threshould. Value is not a positive int");
+            }
+
+            limit = v;
+            cacher.reset();
+        }
+    });
+
+    // @ts-expect-error Types are annoying
+    cacher.get = undefined as T;
+    Object.defineProperty(cacher, "get", {
+        get: () => cacher()
+    });
+
+    return cacher;
+}
+
+cache.proxy = <T extends object>(factory: () => T, typeofIsObject: boolean = false, CALL_LIMIT: number = Infinity): T => {
+    const handlers: ProxyHandler<T> = {};
+
+    const cFactory = cache(factory);
+    cFactory.CALL_LIMIT = CALL_LIMIT;
+
+    const cacheFactory = () => {
+        if (!cFactory.hasValue()) return cFactory();
+        if (cFactory() instanceof Object) return cFactory();
+        // Attempt to hopefully have the results be a instance of Object
+        cFactory.reset();
+        return cFactory();
+    };
+
+    for (const key of Object.getOwnPropertyNames(Reflect) as Array<keyof typeof Reflect>) {
+        const handler = Reflect[key];
+
+        if (key === "get") {
+            handlers.get = (_, prop, r) => {
+                if (prop === "prototype") return (cacheFactory() as any).prototype ?? Function.prototype;
+                if (prop === Symbol.for("betterdiscord.cache.proxy")) return cFactory;
+                return Reflect.get(cacheFactory(), prop, r);
+            };
+            continue;
+        }
+        if (key === "ownKeys") {
+            handlers.ownKeys = () => {
+                const keys = Reflect.ownKeys(cacheFactory());
+                if (!typeofIsObject && !keys.includes("prototype")) keys.push("prototype");
+                return keys;
+            };
+            continue;
+        }
+
+        // @ts-expect-error Types are annoying
+        handlers[key] = function (target, ...args) {
+            // @ts-expect-error Types are annoying
+            return handler.apply(this, [cacheFactory(), ...args]);
+        };
+    }
+
+    const proxy = new Proxy(Object.assign(typeofIsObject ? {} : function () {}, {
+        [Symbol.for("betterdiscord.cache.proxy")]: cFactory
+    }) as T, handlers);
+
+    return proxy;
+};

--- a/src/common/utils/cache.ts
+++ b/src/common/utils/cache.ts
@@ -13,7 +13,7 @@ export interface Cache<T> {
      */
     hasValue(): boolean,
     /**
-     * Completly resets the cache factory
+     * Completely resets the cache factory
      *
      * @example
      * const foo = cache(() => console.log("Called"));
@@ -68,7 +68,7 @@ export default function cache<T>(factory: () => T): Cache<T> {
         get: () => limit,
         set: (v) => {
             if (typeof v !== "number" || isNaN(v) || v <= 0 || Math.round(v) !== v) {
-                throw new Error("Unable to set max call threshould. Value is not a positive int");
+                throw new Error("Unable to set max call threshold. Value is not a positive int");
             }
 
             limit = v;
@@ -93,7 +93,9 @@ cache.proxy = <T extends object>(factory: () => T, typeofIsObject: boolean = fal
 
     const cacheFactory = () => {
         if (!cFactory.hasValue()) return cFactory();
-        if (cFactory() instanceof Object) return cFactory();
+
+        const cached = cFactory();
+        if (cached instanceof Object) return cached;
         // Attempt to hopefully have the results be a instance of Object
         cFactory.reset();
         return cFactory();

--- a/src/electron/preload/early/index.ts
+++ b/src/electron/preload/early/index.ts
@@ -81,7 +81,7 @@ function toStringFunction(stringed: string): string {
     */
     (${moduleString.slice(0, functionBody)}arguments[0].declarations=${declarationString};${moduleString.slice(functionBody)}).apply(this, arguments)
 });
-//# sourceURL=betterdiscord://BD/webpack-modules/patched/${path}`;
+//# sourceURL=betterdiscord://betterdiscord/webpack-modules/patched/${path}`;
 
                     // eslint-disable-next-line no-eval
                     rawModule = (0, eval)(stringedModule);


### PR DESCRIPTION
Fixes an issue with the types generator script

Adds Webpack.getProxy/getBulkProxy/getBulkKeyedProxy/getMangledProxy and Utils.cache/cache.proxy

Additionally makes it so BDFDB will always load (Rather not deal with people complaining)