### PR TITLE
Fix ~40 bugs found in a pre-release audit

### DIFF
--- a/src/betterdiscord/api/commands.ts
+++ b/src/betterdiscord/api/commands.ts
@@ -117,7 +117,8 @@ class BoundCommandAPI {
 
 Object.freeze(CommandAPI);
 Object.freeze(CommandAPI.prototype);
-Object.freeze(CommandAPI.prototype.Types);
-Object.freeze(CommandAPI.constructor);
+Object.freeze(Types);
+Object.freeze(BoundCommandAPI);
+Object.freeze(BoundCommandAPI.prototype);
 
 export {CommandAPI, BoundCommandAPI};

--- a/src/betterdiscord/api/contextmenu.ts
+++ b/src/betterdiscord/api/contextmenu.ts
@@ -279,7 +279,7 @@ class MenuPatcher {
         // .colorDanger.focused:not(.checkboxContainer) path {fill: var(--text-feedback-critical)}
 
         DOMManager.injectStyle("bd-lucide-context-menu-fix", `
-            :where(.${menuClasses!.colorDefault}, ${menuClasses!.colorDanger}).${menuClasses!.focused}:not(.${menuClasses!.checkboxContainer}) .lucide:not(.lucide-betterdiscord) path {
+            :where(.${menuClasses!.colorDefault}, .${menuClasses!.colorDanger}).${menuClasses!.focused}:not(.${menuClasses!.checkboxContainer}) .lucide:not(.lucide-betterdiscord) path {
                 fill: revert;
             }
         `);
@@ -510,7 +510,7 @@ class ContextMenu {
         else if (type === "control") {
             Component = MenuComponents.ControlItem;
         }
-        if (!props.id) props.id = `${props.label.replace(/^[^a-z]+|[^\w-]+/gi, "-")}`;
+        if (!props.id) props.id = `${(props.label ?? `${type ?? "item"}`).replace(/^[^a-z]+|[^\w-]+/gi, "-")}`;
 
         if (props.type !== "control") {
             if (props.danger) (props as BaseMenuItemProps).color = "danger";

--- a/src/betterdiscord/api/patcher.ts
+++ b/src/betterdiscord/api/patcher.ts
@@ -8,7 +8,7 @@ type AsAfterCallback<M extends object, K extends StringKeys<M>> = M[K] extends (
 type AsInsteadCallback<M extends object, K extends StringKeys<M>> = M[K] extends (...a: any[]) => any ? InsteadCallback<M[K]> : never;
 
 function isModuleInvalid(moduleToPatch: any): boolean {
-    return typeof moduleToPatch !== "object" && typeof moduleToPatch !== "function" && moduleToPatch !== null;
+    return (typeof moduleToPatch !== "object" && typeof moduleToPatch !== "function") || moduleToPatch === null;
 }
 
 /**

--- a/src/betterdiscord/api/ui.ts
+++ b/src/betterdiscord/api/ui.ts
@@ -49,7 +49,14 @@ class UI {
      * @returns An object with `isVisible` and `close` methods
      */
     showNotification(options: Notification) {
-        if (!Settings.get("settings", "general", "notificationEnabled")) return;
+        // Keep the documented return shape even when notifications are disabled
+        if (!Settings.get("settings", "general", "notificationEnabled")) {
+            return {
+                id: options?.id,
+                isVisible: () => false,
+                close: () => {}
+            };
+        }
 
         const defaultObj = {
             title: "",

--- a/src/betterdiscord/builtins/customcss.ts
+++ b/src/betterdiscord/builtins/customcss.ts
@@ -108,6 +108,10 @@ export default new class CustomCSS extends Builtin {
                 if ((err as ErrnoException).code !== "ENOENT") return;
                 delete timeCache[filename];
                 this.saveCSS("");
+                // The deletion event is a "rename", so clear the injected CSS here too
+                this.insertCSS("");
+                Events.emit("customcss-updated", "");
+                return;
             }
             const stats = fs.statSync(this.file);
             if (!stats || !stats.mtimeMs) return;

--- a/src/betterdiscord/builtins/store/addonstore.ts
+++ b/src/betterdiscord/builtins/store/addonstore.ts
@@ -55,7 +55,7 @@ function extractAddonLinks(text: string, max = Infinity) {
         // if <betterdiscord://addon/id> not betterdiscord://addon/id
         if (exec[0][0] === "h" && text[exec.index - 1] === "<") continue;
 
-        const endIndex = exec.index + exec.length;
+        const endIndex = exec.index + exec[0].length;
 
         let isInCodeblock = false;
         for (const [start, end] of codeblocks) {
@@ -133,11 +133,13 @@ export default new class AddonStoreBuiltin extends Builtin {
         }
     }
 
-    private linkOpener?: Generator;
+    private linkOpener?: [any, any];
     async patchLinkOpener() {
-        const [module, key] = this.linkOpener ??= getWithKey((m) => String(m).includes(".trackAnnouncementMessageLinkClicked("), {
+        // Cache the resolved [module, key] pair, not the generator — a generator can only be consumed once,
+        // which silently broke this patch when the builtin was re-enabled
+        const [module, key] = this.linkOpener ??= [...getWithKey((m) => String(m).includes(".trackAnnouncementMessageLinkClicked("), {
             target: await getLazyBySource([".trackAnnouncementMessageLinkClicked("])
-        });
+        })] as [any, any];
 
         this.before(module, key, (_, args) => {
             if (args[0].href) {
@@ -174,7 +176,13 @@ export default new class AddonStoreBuiltin extends Builtin {
             return includes.apply(this, args);
         };
 
-        link.parse(["", "link", "betterdiscord://foo/bar"]);
+        try {
+            link.parse(["", "link", "betterdiscord://foo/bar"]);
+        }
+        finally {
+            // Never leave the global patched if parse throws or the interception never triggers
+            Array.prototype.includes = includes;
+        }
 
         return this.protocolList = protocols;
     }

--- a/src/betterdiscord/modules/addonmanager.ts
+++ b/src/betterdiscord/modules/addonmanager.ts
@@ -345,7 +345,7 @@ export default abstract class AddonManager<T extends Addon = Addon> extends Stor
         const fullPath = path.resolve(this.addonFolder, addon.filename);
         if (typeof system == "undefined") system = Settings.get("settings", "addons", "editAction");
 
-        if (system === "system") return ipc.openPath(`${fullPath}`);
+        if (system === "system" || system === true) return ipc.openPath(`${fullPath}`);
         else if (system === "external") return RemoteAPI.editor.open(this.prefix as "theme", addon.filename);
         return this.openDetached(addon);
     }

--- a/src/betterdiscord/modules/dommanager.ts
+++ b/src/betterdiscord/modules/dommanager.ts
@@ -79,14 +79,12 @@ export default class DOMManager {
     }
 
     static removeStyle(id: string) {
-        id = this.escapeID(id);
-        const exists = this.getElement(`#${id}`, this.bdStyles);
+        const exists = this.getElement(`#${this.escapeID(id)}`, this.bdStyles);
         if (exists) exists.remove();
     }
 
     static injectStyle(id: string, css: string) {
-        id = this.escapeID(id);
-        const style = this.getElement(`#${id}`, this.bdStyles) || this.createElement("style", {id});
+        const style = this.getElement(`#${this.escapeID(id)}`, this.bdStyles) || this.createElement("style", {id});
         style.textContent = css;
         this.bdStyles.append(style);
     }
@@ -96,9 +94,8 @@ export default class DOMManager {
     }
 
     static linkStyle(id: string, url: string, {documentHead = false} = {}) {
-        id = this.escapeID(id);
         return new Promise(resolve => {
-            const link: HTMLLinkElement = this.getElement(`#${id}`, this.bdStyles) as HTMLLinkElement || this.createElement("link", {id});
+            const link: HTMLLinkElement = this.getElement(`#${this.escapeID(id)}`, this.bdStyles) as HTMLLinkElement || this.createElement("link", {id});
             link.rel = "stylesheet";
             link.href = url;
             link.onload = resolve;
@@ -108,13 +105,11 @@ export default class DOMManager {
     }
 
     static removeTheme(id: string) {
-        id = this.escapeID(id);
         const exists = document.getElementById(id);
         if (exists) exists.remove();
     }
 
     static injectTheme(id: string, css: string) {
-        id = this.escapeID(id);
         const style = document.getElementById(id) || this.createElement("style", {id});
         style.textContent = css;
         this.bdThemes.append(style);
@@ -125,15 +120,13 @@ export default class DOMManager {
     }
 
     static removeScript(id: string) {
-        id = this.escapeID(id);
-        const exists = this.getElement(`#${id}`, this.bdScripts);
+        const exists = this.getElement(`#${this.escapeID(id)}`, this.bdScripts);
         if (exists) exists.remove();
     }
 
     static injectScript(id: string, url: string) {
-        id = this.escapeID(id);
         return new Promise((resolve, reject) => {
-            const script: HTMLScriptElement = this.getElement(`#${id}`, this.bdScripts) as HTMLScriptElement || this.createElement("script", {id});
+            const script: HTMLScriptElement = this.getElement(`#${this.escapeID(id)}`, this.bdScripts) as HTMLScriptElement || this.createElement("script", {id});
             script.src = url;
             script.onload = resolve;
             script.onerror = reject;

--- a/src/betterdiscord/modules/patcher.ts
+++ b/src/betterdiscord/modules/patcher.ts
@@ -260,7 +260,9 @@ export default class Patcher {
             id: patch.counter,
             callback,
             unpatch: () => {
-                patch.children.splice(patch.children.findIndex(cpatch => cpatch.id === child.id && cpatch.type === type), 1);
+                const childIndex = patch.children.findIndex(cpatch => cpatch.id === child.id && cpatch.type === type);
+                if (childIndex < 0) return; // Already unpatched, don't remove someone else's patch
+                patch.children.splice(childIndex, 1);
                 if (patch.children.length <= 0) {
                     const patchNum = this.patches.findIndex(p => p.module == module && p.functionName == functionName);
                     if (patchNum < 0) return;

--- a/src/betterdiscord/modules/updater.ts
+++ b/src/betterdiscord/modules/updater.ts
@@ -41,7 +41,12 @@ const getJSON = (url: string) => {
             }
         }, (error: Error, _: Response, body: string) => {
             if (error) return resolve([]);
-            resolve(JSON.parse(body));
+            try {
+                resolve(JSON.parse(body));
+            }
+            catch {
+                resolve([]);
+            }
         });
     });
 };
@@ -123,6 +128,7 @@ export class CoreUpdater {
         });
 
         const data: Release = await resp.json();
+        if (typeof data?.tag_name !== "string") throw new Error(`Unexpected response checking for updates (status ${resp.status})`);
         const remoteVersion = data.tag_name.startsWith("v") ? data.tag_name.slice(1) : data.tag_name;
         this.hasUpdate = ignoreVersion || semverComparator(Config.get("version"), remoteVersion) > 0;
         this.remoteVersion = remoteVersion;
@@ -177,8 +183,15 @@ export class CoreUpdater {
          * But if the user is already on canary, then pass a
          * flag to ignore remove version.
          */
-        if (isCanaryEnabled) await this.checkForCanary(!isOnCanary);
-        else await this.checkForStable(isOnCanary);
+        try {
+            if (isCanaryEnabled) await this.checkForCanary(!isOnCanary);
+            else await this.checkForStable(isOnCanary);
+        }
+        catch (error) {
+            // Network failures and rate limits shouldn't produce unhandled rejections
+            Logger.warn("Updater", "Failed to check for core update", error);
+            return;
+        }
 
         if (!this.hasUpdate || !showNotice) return;
 
@@ -310,15 +323,21 @@ export class AddonUpdater {
             }
         }, (error: Error, response: {statusCode: number;}, body: string) => {
             if (error || response.statusCode !== 200) {
-                Logger.stacktrace("AddonUpdater", `Failed to download body for ${info.id}:`, error);
+                Logger.stacktrace("AddonUpdater", `Failed to download body for ${info.id}:`, error ?? new Error(`Status ${response.statusCode}`));
                 Toasts.error(t("Updater.addonUpdateFailed", {name: info.name, version: info.version}));
                 return;
             }
 
             const file = path.join(path.resolve(this.manager.addonFolder), filename);
-            fileSystem.writeFile(file, body.toString(), () => {
+            fileSystem.writeFile(file, body.toString(), (writeError) => {
+                if (writeError) {
+                    Logger.stacktrace("AddonUpdater", `Failed to write update for ${info.id}:`, writeError);
+                    Toasts.error(t("Updater.addonUpdateFailed", {name: info.name, version: info.version}));
+                    return;
+                }
                 Toasts.success(t("Updater.addonUpdated", {name: info.name, version: info.version}));
-                this.pending.splice(this.pending.indexOf(filename), 1);
+                const pendingIndex = this.pending.indexOf(filename);
+                if (pendingIndex >= 0) this.pending.splice(pendingIndex, 1);
             });
         });
     }

--- a/src/betterdiscord/polyfill/fs.ts
+++ b/src/betterdiscord/polyfill/fs.ts
@@ -13,13 +13,16 @@ function wrapFunctionWithCallback<
     return function (...args: [...Parameters<T>, C]) {
         const params = args.slice(0, -1) as Parameters<T>;
         const callback = args[args.length - 1] as C;
+        let result;
         try {
-            const result = func(...params);
-            callback(null, result);
+            result = func(...params);
         }
         catch (error) {
             callback(error as Error, null);
+            return;
         }
+        // Outside the try so an error thrown by the callback isn't fed back into it
+        callback(null, result);
     };
 }
 
@@ -68,11 +71,12 @@ export const writeFile = function (path: fs.PathOrFileDescriptor, data: string |
 
     try {
         Remote.filesystem.writeFile(path, data, options as WriteOptions);
-        callback?.(null);
     }
     catch (error) {
         callback?.(error as Error);
+        return;
     }
+    callback?.(null);
 };
 
 export const lstat = stat;

--- a/src/betterdiscord/polyfill/https.ts
+++ b/src/betterdiscord/polyfill/https.ts
@@ -4,7 +4,7 @@ import type {RequestOptions} from "@common/types/ipc";
 import Remote from "./remote";
 
 
-export function get(url: string, options: null | RequestOptions | ((e: EventEmitter) => void) = {}, callback: (e: EventEmitter) => void) {
+export function get(url: string, options: null | RequestOptions | ((e: EventEmitter) => void) = {}, callback?: (e: EventEmitter) => void) {
     if (typeof (options) === "function") {
         callback = options;
         options = null;
@@ -12,7 +12,7 @@ export function get(url: string, options: null | RequestOptions | ((e: EventEmit
 
     const emitter = new EventEmitter();
 
-    callback(emitter);
+    callback?.(emitter);
 
     Remote.https.get(url, options ?? {}, (error: Error, res?: Record<string, any>, body?: Buffer | string) => {
         if (error) return emitter.emit("error", error);

--- a/src/betterdiscord/polyfill/index.ts
+++ b/src/betterdiscord/polyfill/index.ts
@@ -16,9 +16,18 @@ const deprecated = new Map([
 ]);
 
 
+// Node allows a bare encoding string in place of the options object
+const withOriginalFs = (options: unknown) => Object.assign({}, typeof options === "string" ? {encoding: options} : options, {originalFs: true});
+
 const originalFs = Object.assign({}, fs);
-originalFs.writeFileSync = (path, data, options) => fs.writeFileSync(path, data, Object.assign({}, options, {originalFs: true}));
-originalFs.writeFile = (path, data, options) => fs.writeFile(path, data, Object.assign({}, options, {originalFs: true}));
+originalFs.writeFileSync = (path, data, options) => fs.writeFileSync(path, data, withOriginalFs(options));
+originalFs.writeFile = (path, data, options, callback) => {
+    if (typeof options === "function") {
+        callback = options;
+        options = undefined;
+    }
+    return fs.writeFile(path, data, withOriginalFs(options), callback);
+};
 
 type PolyfillRequire = ((mod: string) => any) & {cache?: Record<string, any>; resolve?(path: string): any;};
 

--- a/src/betterdiscord/polyfill/module.ts
+++ b/src/betterdiscord/polyfill/module.ts
@@ -25,7 +25,8 @@ export const RequireExtensions = {
 
 export default class Module {
     static resolveMainFile(mod: string, basePath: string) {
-        const parent = path.extname(basePath) ? path.dirname(basePath) : basePath;
+        if (!path.isAbsolute(mod)) mod = path.resolve(basePath, mod);
+        const parent = path.extname(mod) ? path.dirname(mod) : mod;
         const files = Remote.filesystem.readDirectory(parent);
         if (!Array.isArray(files)) return null;
 
@@ -40,8 +41,12 @@ export default class Module {
                 return path.resolve(parent, pkg.main);
             }
 
-            if (ext.slice(0, -ext.length) == "index" && RequireExtensions[ext as keyof typeof RequireExtensions]) return mod;
+            if ((file as string).slice(0, -ext.length) === "index" && RequireExtensions[ext as keyof typeof RequireExtensions]) {
+                return path.resolve(parent, file as string);
+            }
         }
+
+        return null;
     }
 
     static getExtension(mod: string) {
@@ -64,17 +69,25 @@ export default class Module {
     static _load(mod: string, basePath: string, createRequire: (m: string) => any) {
         const originalReq = mod;
         if (!path.isAbsolute(mod)) mod = path.resolve(basePath, mod);
-        const filePath = this.getFilePath(basePath, mod);
+        let filePath = this.getFilePath(basePath, mod);
         if (!Remote.filesystem.exists(filePath)) throw new Error(`Cannot find module ${mod}`);
-        if (window.require.cache[filePath]) return window.require.cache[filePath].exports;
+        const cached = window.require.cache[filePath];
+        if (cached) return cached.exports;
         const stats = Remote.filesystem.getStats(filePath);
-        if (stats.isDirectory()) mod = this.resolveMainFile(mod, basePath)!;
+        if (stats.isDirectory()) {
+            const mainFile = this.resolveMainFile(filePath, basePath);
+            if (!mainFile) throw new Error(`Cannot find module ${originalReq}`);
+            filePath = this.getFilePath(basePath, mainFile);
+            if (!Remote.filesystem.exists(filePath)) throw new Error(`Cannot find module ${originalReq}`);
+            const cachedMain = window.require.cache[filePath];
+            if (cachedMain) return cachedMain.exports;
+        }
         const ext = this.getExtension(filePath);
         const loader = RequireExtensions[ext as keyof typeof RequireExtensions];
 
         if (!loader) throw new Error(`Cannot find module ${originalReq}`);
         // @ts-expect-error no, remove with polyfill
-        const module = window.require.cache[mod] = new Module(filePath, internalModule, createRequire(mod));
+        const module = window.require.cache[filePath] = new Module(filePath, internalModule, createRequire(filePath));
         loader(module, filePath);
         return module.exports;
     }

--- a/src/betterdiscord/secure.ts
+++ b/src/betterdiscord/secure.ts
@@ -3,6 +3,7 @@ export default function () {
     Object.defineProperty(HTMLIFrameElement.prototype, "contentWindow", {
         get: function (...args: any[]) {
             const contentWindow = Reflect.apply(contentWindowGetter, this, args);
+            if (!contentWindow) return contentWindow; // Detached iframes have no contentWindow
             return new Proxy(contentWindow, {
                 getOwnPropertyDescriptor: function (obj, prop) {
                     if (prop === "localStorage") return undefined;
@@ -24,7 +25,7 @@ export default function () {
 
     const oOpen = XMLHttpRequest.prototype.open;
     XMLHttpRequest.prototype.open = function (...args: any[]) {
-        const url = args[1];
+        const url = String(args[1]); // URL objects are valid here too
         if (url.toLowerCase().includes("api/webhooks")) return null;
         return Reflect.apply(oOpen, this, args);
     };

--- a/src/betterdiscord/stores/json.ts
+++ b/src/betterdiscord/stores/json.ts
@@ -1,5 +1,6 @@
 import fs from "@polyfill/fs";
 import path from "path";
+import {deepEqual} from "fast-equals";
 import Store from "./base";
 import Config from "./config";
 import Logger from "@common/logger";
@@ -123,8 +124,8 @@ class JsonStore extends Store {
             };
 
             for (const k of beforeSet) {
-                if (afterSet.has(k)) result.changed.push(k);
-                else result.deleted.push(k);
+                if (!afterSet.has(k)) result.deleted.push(k);
+                else if (!deepEqual(before[k], after[k])) result.changed.push(k);
             }
 
             for (const k of afterSet) {

--- a/src/betterdiscord/ui/floating/window.tsx
+++ b/src/betterdiscord/ui/floating/window.tsx
@@ -175,7 +175,7 @@ export default function FloatingWindow({id, title, resizable, children, classNam
         if (newLeft < positioning.current.min.x) {
             const difference = positioning.current.min.x - newLeft;
             window.current!.style.left = positioning.current.min.x + "px";
-            window.current!.style.height = (width - difference) + "px";
+            window.current!.style.width = (width - difference) + "px";
         }
     }, [window, onResize]);
 

--- a/src/betterdiscord/ui/modals.ts
+++ b/src/betterdiscord/ui/modals.ts
@@ -67,7 +67,11 @@ export default class Modals {
                 </div>
             </div>`) as HTMLElement;
 
+        let isClosing = false;
         const handleClose = () => {
+            // Multiple handlers can trigger a close; only run it once so the queue isn't shifted repeatedly
+            if (isClosing) return;
+            isClosing = true;
             modal.classList.add("closing");
             setTimeout(() => {
                 modal.remove();
@@ -223,7 +227,7 @@ export default class Modals {
 
     static showChangelogModal(options: ChangelogProps = {}) {
         const key = this.openModal(props => {
-            return React.createElement(ErrorBoundary, {id: "showChangelogModal", name: "Modals"}, React.createElement(ChangelogModal, Object.assign(options, props)));
+            return React.createElement(ErrorBoundary, {id: "showChangelogModal", name: "Modals"}, React.createElement(ChangelogModal, Object.assign({}, options, props)));
         });
         return key;
     }

--- a/src/betterdiscord/ui/notices.ts
+++ b/src/betterdiscord/ui/notices.ts
@@ -55,7 +55,10 @@ export default class Notices {
         const haveContainer = this.ensureContainer();
         if (!haveContainer) return;
 
+        let closed = false;
         const closeNotification = function (immediately = false) {
+            if (closed) return; // Timeout and manual close can race; only close once
+            closed = true;
             onClose?.();
             // Immediately remove the notice without adding the closing class.
             if (immediately) return noticeElement.remove();

--- a/src/betterdiscord/ui/settings/addonlist.tsx
+++ b/src/betterdiscord/ui/settings/addonlist.tsx
@@ -189,8 +189,8 @@ export default function AddonList({store}: {store: AddonManager;}) {
                 ? typeof (addon as Plugin).instance?.getSettingsPanel === "function"
                 : Boolean(store.prefix === "plugin" && addon.fileContent?.includes("getSettingsPanel"));
             const getSettings = hasSettings && (addon as Plugin).instance?.getSettingsPanel?.bind((addon as Plugin).instance);
-            return <ErrorBoundary id={addon.id} name="AddonCard">
-                <AddonCard store={store} disabled={addon.partial} type={store.prefix as AddonType} editAddon={() => triggerEdit(addon.id)} deleteAddon={() => triggerDelete(addon.id)} key={addon.id} addon={addon} onChange={onChange} enabled={addonState[addon.id]} hasSettings={hasSettings} getSettingsPanel={getSettings ? getSettings : undefined} />
+            return <ErrorBoundary id={addon.id} name="AddonCard" key={addon.id}>
+                <AddonCard store={store} disabled={addon.partial} type={store.prefix as AddonType} editAddon={() => triggerEdit(addon.id)} deleteAddon={() => triggerDelete(addon.id)} addon={addon} onChange={onChange} enabled={addonState[addon.id]} hasSettings={hasSettings} getSettingsPanel={getSettings ? getSettings : undefined} />
             </ErrorBoundary>;
         });
     }, [store, addonList, addonState, onChange, triggerDelete, triggerEdit, query, ascending, sort]);

--- a/src/betterdiscord/ui/settings/components/color.tsx
+++ b/src/betterdiscord/ui/settings/components/color.tsx
@@ -15,7 +15,7 @@ function resolveColor(color: ColorType, hex: false): number;
 function resolveColor(color: ColorType, hex?: true): HexString;
 function resolveColor(color: ColorType, hex = true): HexString | number {
     switch (typeof color) {
-        case (hex && "number"): return `#${color.toString(16)}`;
+        case (hex && "number"): return `#${(color as number).toString(16).padStart(6, "0")}`;
         case (!hex && "string"): return Number.parseInt((color as HexString).replace("#", ""), 16);
         case (!hex && "number"): return color;
         case (hex && "string"): return color;
@@ -96,7 +96,7 @@ export default function ColorPicker(props: ColorpickerProps) {
             {
                 colors.map((int, index) => (
                     <div key={index} className="bd-color-picker-swatch-item" style={{backgroundColor: resolveColor(int)}} onClick={() => change({target: {value: int}})}>
-                        {intValue === int
+                        {intValue === resolveColor(int, false)
                             ? <CheckIcon size="16px" color={getContrastColor(resolveColor(value, true))} />
                             : null
                         }

--- a/src/betterdiscord/ui/tooltip.ts
+++ b/src/betterdiscord/ui/tooltip.ts
@@ -93,6 +93,7 @@ export default class Tooltip {
         if (!this.active) return;
         this.active = false;
         this.element.remove();
+        this.observer?.disconnect();
     }
 
     /** Shows the tooltip. Automatically called on mouseenter. Will attempt to flip if position was wrong. */
@@ -124,47 +125,51 @@ export default class Tooltip {
         }
 
         // Do not create a new observer each time if one already exists!
-        if (this.observer) return;
         // Use an observer in show otherwise you'll cause unclosable tooltips
-        this.observer = new MutationObserver((mutations) => {
+        this.observer ??= new MutationObserver((mutations) => {
             mutations.forEach((mutation) => {
                 const nodes = Array.from(mutation.removedNodes);
                 const directMatch = nodes.indexOf(this.node) > -1;
                 const parentMatch = nodes.some(parent => parent.contains(this.node));
                 if (directMatch || parentMatch) {
                     this.hide();
-                    this.observer?.disconnect();
                 }
             });
         });
 
+        // (Re)connect on every show; hide() disconnects it
         this.observer.observe(document.body, {subtree: true, childList: true});
+    }
+
+    #setSideClass(side: "top" | "bottom" | "left" | "right") {
+        this.tooltipElement.classList.remove("bd-tooltip-top", "bd-tooltip-bottom", "bd-tooltip-left", "bd-tooltip-right");
+        this.tooltipElement.classList.add(`bd-tooltip-${side}`);
     }
 
     /** Force showing the tooltip above the node. */
     showAbove() {
-        this.tooltipElement.classList.add("bd-tooltip-top");
+        this.#setSideClass("top");
         this.element.style.setProperty("top", toPx(this.node.getBoundingClientRect().top - this.element.offsetHeight - 10));
         this.centerHorizontally();
     }
 
     /** Force showing the tooltip below the node. */
     showBelow() {
-        this.tooltipElement.classList.add("bd-tooltip-bottom");
+        this.#setSideClass("bottom");
         this.element.style.setProperty("top", toPx(this.node.getBoundingClientRect().top + this.node.offsetHeight + 10));
         this.centerHorizontally();
     }
 
     /** Force showing the tooltip to the left of the node. */
     showLeft() {
-        this.tooltipElement.classList.add("bd-tooltip-left");
+        this.#setSideClass("left");
         this.element.style.setProperty("left", toPx(this.node.getBoundingClientRect().left - this.element.offsetWidth - 10));
         this.centerVertically();
     }
 
     /** Force showing the tooltip to the right of the node. */
     showRight() {
-        this.tooltipElement.classList.add("bd-tooltip-right");
+        this.#setSideClass("right");
         this.element.style.setProperty("left", toPx(this.node.getBoundingClientRect().left + this.node.offsetWidth + 10));
         this.centerVertically();
     }

--- a/src/betterdiscord/ui/updater.tsx
+++ b/src/betterdiscord/ui/updater.tsx
@@ -86,8 +86,9 @@ export default function UpdaterPanel({coreUpdater, pluginUpdater, themeUpdater}:
     const checkAddons = useCallback(async (type: "plugins" | "themes") => {
         const updater = type === "plugins" ? pluginUpdater : themeUpdater;
         await updater.checkAll(false);
-        setUpdates({...updates, [type]: updater.pending.slice(0)});
-    }, [updates, pluginUpdater, themeUpdater]);
+        // Functional update so concurrent checks can't clobber each other with stale state
+        setUpdates(prev => ({...prev, [type]: updater.pending.slice(0)}));
+    }, [pluginUpdater, themeUpdater]);
 
     const update = useCallback(() => {
         checkAddons("plugins");
@@ -132,10 +133,7 @@ export default function UpdaterPanel({coreUpdater, pluginUpdater, themeUpdater}:
     const updateAddon = useCallback(async (type: "plugins" | "themes", filename: string) => {
         const updater = type === "plugins" ? pluginUpdater : themeUpdater;
         await updater.updateAddon(filename);
-        setUpdates(prev => {
-            prev[type].splice(prev[type].indexOf(filename), 1);
-            return prev;
-        });
+        setUpdates(prev => ({...prev, [type]: prev[type].filter(f => f !== filename)}));
     }, [pluginUpdater, themeUpdater]);
 
     const updateAllAddons = useCallback(async (type: "plugins" | "themes") => {

--- a/src/betterdiscord/utils/icon.ts
+++ b/src/betterdiscord/utils/icon.ts
@@ -32,11 +32,19 @@ type DiscordToLucide = (lucide: DiscordIcon, middleWare?: DiscordMiddleware) => 
 
 // TODO: Extend for all discord icon prop types
 export const lucideToDiscordIcon: LucideToDiscord = (lucide, middleWare = v => v) => memo(
-    (props) => React.createElement(lucide, middleWare({
-        size: sizes[props.size || "md"],
-        className: props.className,
-        color: props.color
-    }, props))
+    (props) => {
+        const lucideProps: LucideProps = {
+            size: sizes[props.size || "md"],
+            className: props.className,
+            color: props.color
+        };
+        if (props.size === "custom") {
+            const {width, height} = props as {width?: LucideProps["width"]; height?: LucideProps["height"];};
+            lucideProps.width = width;
+            lucideProps.height = height;
+        }
+        return React.createElement(lucide, middleWare(lucideProps, props));
+    }
 );
 
 export const discordIconToLucide: DiscordToLucide = (discord, middleWare = v => v) => memo(

--- a/src/betterdiscord/webpack/lazy.ts
+++ b/src/betterdiscord/webpack/lazy.ts
@@ -4,9 +4,10 @@ import {lazyListeners, webpackRequire} from "./require";
 import {shouldSkipModule, getDefaultKey, wrapModuleFilter, makeException, getDeclaration} from "./shared";
 import {getBulk} from "./utilities";
 
-const ChunkIdRegex = /.{1}\.e\("(\d+)"\)/g;
-const FinalModuleIdRegex = /.{1}\.bind\(.{1},\s*(\d+)\s*\)/g;
-const CreatePromiseId = /createPromise:\s*\(\)\s*=>\s*([^}]+)\.then\(.{1}\.bind\(.{1},\s*(\d+)\)\)/g;
+// Sources only — instantiate per use so shared `lastIndex` state can't leak across (possibly concurrent) calls
+const ChunkIdRegexSource = /.{1}\.e\("(\d+)"\)/.source;
+const FinalModuleIdRegexSource = /.{1}\.bind\(.{1},\s*(\d+)\s*\)/.source;
+const CreatePromiseIdSource = /createPromise:\s*\(\)\s*=>\s*([^}]+)\.then\(.{1}\.bind\(.{1},\s*(\d+)\)\)/.source;
 
 interface LazyQueue<T = any> {
     query: Webpack.BulkQueries;
@@ -22,33 +23,40 @@ const queue = {
     _queue: <LazyQueue[]>[],
     /** @private */
     _flushSync() {
-        // Should make it faster?
-        if (this._queue.length === 0) {
-            this._scheduled = false;
-            return;
+        try {
+            // Should make it faster?
+            if (this._queue.length === 0) {
+                return;
+            }
+            if (this._queue.length === 1) {
+                const [{resolve, query: {filter, ...options}}] = this._queue;
+
+                resolve({state: "resolved", value: getModule<any>(filter, options)});
+
+                return;
+            }
+
+            const result = getBulk(...this._queue.map((x) => x.query));
+
+            for (let index = 0; index < this._queue.length; index++) {
+                this._queue[index].resolve({
+                    state: "resolved",
+                    value: result[index]
+                });
+            }
         }
-        if (this._queue.length === 1) {
-            const [{resolve, query: {filter, ...options}}] = this._queue;
-
-            resolve({state: "resolved", value: getModule<any>(filter, options)});
-
+        catch (error) {
+            // Settle whatever is left so callers fall back to lazy listeners instead of hanging
+            for (const item of this._queue) {
+                item.resolve({state: "resolved", value: undefined});
+            }
+            throw error;
+        }
+        finally {
+            // Always reset state so one bad search can't wedge the queue permanently
             this._queue.length = 0;
             this._scheduled = false;
-
-            return;
         }
-
-        const result = getBulk(...this._queue.map((x) => x.query));
-
-        for (let index = 0; index < this._queue.length; index++) {
-            this._queue[index].resolve({
-                state: "resolved",
-                value: result[index]
-            });
-        }
-
-        this._queue.length = 0;
-        this._scheduled = false;
     },
     /** @private */
     _scheduleFlush() {
@@ -109,11 +117,13 @@ export async function getLazy<T>(filter: Webpack.ModuleFilter, options: Webpack.
     filter = wrapModuleFilter(filter);
 
     return new Promise((resolve, reject) => {
-        const cancel = () => void lazyListeners.delete(listener);
+        const cancel = () => {
+            lazyListeners.delete(listener);
+            abortSignal?.removeEventListener("abort", onAbort);
+        };
 
         const onAbort = () => {
             cancel();
-            abortSignal?.removeEventListener("abort", onAbort);
             if (fatal) reject(makeException());
             else resolve(undefined);
         };
@@ -172,11 +182,12 @@ export async function forceLoad(id: string | number): Promise<any[]> {
     const loadedModules = [];
     let match;
 
-    while ((match = CreatePromiseId.exec(text)) !== null) {
+    const createPromiseId = new RegExp(CreatePromiseIdSource, "g");
+    while ((match = createPromiseId.exec(text)) !== null) {
         const promiseBody = match[1];
         const bindId = match[2];
         const chunkIds = [];
-        const chunkMatches = promiseBody.matchAll(ChunkIdRegex);
+        const chunkMatches = promiseBody.matchAll(new RegExp(ChunkIdRegexSource, "g"));
         for (const chunkMatch of chunkMatches) {
             chunkIds.push(chunkMatch[1]);
         }
@@ -188,11 +199,12 @@ export async function forceLoad(id: string | number): Promise<any[]> {
 
     const chunkIds = [];
     let chunkMatch;
-    while ((chunkMatch = ChunkIdRegex.exec(text)) !== null) {
+    const chunkIdRegex = new RegExp(ChunkIdRegexSource, "g");
+    while ((chunkMatch = chunkIdRegex.exec(text)) !== null) {
         chunkIds.push(chunkMatch[1]);
     }
 
-    const bindMatches = text.matchAll(FinalModuleIdRegex);
+    const bindMatches = text.matchAll(new RegExp(FinalModuleIdRegexSource, "g"));
     for (const bindMatch of bindMatches) {
         await Promise.all(chunkIds.map((cid) => webpackRequire.e(cid)));
         const loadedModule = webpackRequire(bindMatch[1]);

--- a/src/betterdiscord/webpack/require.ts
+++ b/src/betterdiscord/webpack/require.ts
@@ -94,7 +94,8 @@ function onLoadEnd() {
 function patchModuleLoading(require: Webpack.Require) {
     Patcher.after("WebpackRequire", require, "e", (_, __, loadPromise) => {
         onLoadStart();
-        loadPromise.finally(onLoadEnd);
+        // then(fn, fn) instead of finally(fn) so a failed chunk load doesn't create an unhandled rejection
+        loadPromise.then(onLoadEnd, onLoadEnd);
     });
 
     Patcher.before("WebpackRequire", require, "l", (_, args) => {

--- a/src/betterdiscord/webpack/searching.ts
+++ b/src/betterdiscord/webpack/searching.ts
@@ -28,8 +28,8 @@ export function getMatched<T>(module: Webpack.Module<any>, filter: Webpack.Modul
 
         if (filter(exported, module, module.id)) {
             if (options.declarationFilter) return getDeclaration(module, options.declarationFilter);
-            if (!defaultExport && defaultKey === key) return module.exports;
             if (raw) return module as T;
+            if (!defaultExport && defaultKey === key) return module.exports;
             return exported;
         }
     }

--- a/src/betterdiscord/webpack/utilities.ts
+++ b/src/betterdiscord/webpack/utilities.ts
@@ -134,13 +134,13 @@ export function getBulk<T extends any[]>(...queries: Webpack.BulkQueries[]): T {
     let count = 0;
     const shouldExit = () => shouldExitEarly && count === queries.length;
 
-    // Check the firstId for each query
+    // Check the firstId for each query ("all" queries need the full scan below)
     for (let i = 0; i < queries.length; i++) {
-        const {firstId} = queries[i];
-        if (!firstId) continue;
+        const {firstId, all} = queries[i];
+        if (!firstId || all) continue;
 
         const module = webpackRequire.c[firstId];
-        if (!module) continue;
+        if (!module || shouldSkipModule(module.exports)) continue;
 
         const matched = bulkGetMatched(module, queries[i]);
         if (matched) {
@@ -162,7 +162,7 @@ export function getBulk<T extends any[]>(...queries: Webpack.BulkQueries[]): T {
         if (!id) continue;
 
         const module = webpackRequire.c[id];
-        if (!module) continue;
+        if (!module || shouldSkipModule(module.exports)) continue;
 
         const matched = bulkGetMatched(module, queries[i]);
         if (matched) {

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -17,13 +17,15 @@ export default class EventEmitter {
     emit(event: string, ...args: any[]) {
         if (!this.events[event]) return;
 
-        for (const [index, listener] of this.events[event].entries()) {
+        let index = 0;
+        for (const listener of this.events[event]) {
             try {
                 listener(...args);
             }
             catch (error) {
                 Logger.error("Emitter", `Cannot fire listener for event ${event} at position ${index}:`, error);
             }
+            index++;
         }
     }
 

--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -14,7 +14,9 @@ export default function formatString(string: string, values: Record<string, stri
         if (replacement === null) replacement = "null";
         if (Array.isArray(replacement)) replacement = JSON.stringify(replacement);
         if (typeof (replacement) === "object" && replacement !== null) replacement = replacement.toString();
-        string = string.replace(new RegExp(`{{${val}}}`, "g"), replacement?.toString() ?? "null");
+        const replacementString = replacement?.toString() ?? "null";
+        // Use a replacer function so special patterns like $& in the value aren't interpreted
+        string = string.replace(new RegExp(`{{${val}}}`, "g"), () => replacementString);
     }
     return string;
 }

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -203,7 +203,7 @@ export default class BetterDiscord {
     static disableMediaKeys() {
         if (!BetterDiscord.getSetting("general", "mediaKeys")) return;
         const originalDisable = electron.app.commandLine.getSwitchValue("disable-features") || "";
-        electron.app.commandLine.appendSwitch("disable-features", `${originalDisable ? "," : ""}HardwareMediaKeyHandling,MediaSessionService`);
+        electron.app.commandLine.appendSwitch("disable-features", `${originalDisable ? `${originalDisable},` : ""}HardwareMediaKeyHandling,MediaSessionService`);
     }
 }
 

--- a/src/electron/main/modules/editor.ts
+++ b/src/electron/main/modules/editor.ts
@@ -115,7 +115,7 @@ export default class Editor {
                 };
 
                 this._window.once("closed", listener);
-                window.once("close", () => {
+                window.once("closed", () => {
                     this._window.off("closed", listener);
 
                     if (type === "custom-css") {

--- a/src/electron/main/modules/ipc.ts
+++ b/src/electron/main/modules/ipc.ts
@@ -71,6 +71,7 @@ const createBrowserWindow = (_: IpcMainInvokeEvent, url: string, {windowOptions,
             windowInstance.close();
             resolve();
         });
+        windowInstance.on("closed", () => resolve());
         windowInstance.loadURL(url);
     });
 };
@@ -78,7 +79,10 @@ const createBrowserWindow = (_: IpcMainInvokeEvent, url: string, {windowOptions,
 const inspectElement = async (event: IpcMainEvent) => {
     if (!event.sender.isDevToolsOpened()) {
         event.sender.openDevTools();
-        while (!event.sender.isDevToolsOpened()) await new Promise(r => setTimeout(r, 100));
+        for (let attempts = 0; !event.sender.isDevToolsOpened(); attempts++) {
+            if (attempts >= 50 || event.sender.isDestroyed()) return;
+            await new Promise(r => setTimeout(r, 100));
+        }
     }
     event.sender.devToolsWebContents?.executeJavaScript("DevToolsAPI.enterInspectElementMode();");
 };
@@ -121,7 +125,7 @@ const openDialog = (event: IpcMainInvokeEvent, options: Partial<DialogOptions> =
         open: dialog.showOpenDialog,
         save: dialog.showSaveDialog
     }[mode];
-    if (!openFunction) return Promise.resolve({error: "Unkown Mode: " + mode});
+    if (!openFunction) return Promise.resolve({error: "Unknown Mode: " + mode});
 
     // @ts-expect-error cba to write separate types for these dialogs that are never used
     return openFunction(...[

--- a/src/electron/main/modules/reactdevtools.ts
+++ b/src/electron/main/modules/reactdevtools.ts
@@ -6,6 +6,7 @@ export const REACT_DEVTOOLS_ID = "fmkadmapgofadopljbjfkapdkoienihi";
 
 const findLatestVersion = (extensionPath: string) => {
     const versions = fs.readdirSync(extensionPath);
+    if (!versions.length) return "";
     return path.resolve(extensionPath, versions[versions.length - 1]);
 };
 
@@ -25,6 +26,11 @@ const findExtension = (dataPath: string) => {
     else if (process.platform === "linux") extensionPath = path.resolve(process.env.HOME!, ".config/google-chrome");
     else if (process.platform === "darwin") extensionPath = path.resolve(process.env.HOME!, "Library/Application Support/Google/Chrome");
     else extensionPath = path.resolve(process.env.HOME!, ".config/chromium");
+
+    // No Chrome installation at all
+    if (!fs.existsSync(extensionPath)) {
+        return "";
+    }
 
     // If default profile doesn't exist
     if (!fs.existsSync(extensionPath + "/Default")) {

--- a/src/electron/preload/api/fetch.ts
+++ b/src/electron/preload/api/fetch.ts
@@ -73,7 +73,8 @@ export function nativeFetch({url, signal: dryAbortSignal, body: dryBody, ...init
                 if (res.headers.location) {
                     let final;
                     try {
-                        final = new URL(res.headers.location);
+                        // Location headers may be relative to the requested url
+                        final = new URL(res.headers.location, uri);
                     }
                     catch (error) {
                         reject(error);

--- a/src/electron/preload/api/https.ts
+++ b/src/electron/preload/api/https.ts
@@ -10,33 +10,50 @@ const dataToClone: Array<keyof http.IncomingMessage> = ["statusCode", "statusMes
 
 type SetReq = (res: http.IncomingMessage, req: http.ClientRequest) => void;
 
-const makeRequest = (url: string, options: RequestOptions, callback: RequestCallback, setReq: SetReq) => {
+const MAX_REDIRECTS = 20;
+
+const makeRequest = (url: string, options: RequestOptions, callback: RequestCallback, setReq: SetReq, redirectCount = 0) => {
+    // A failure can surface on both the request and the response objects; only ever call back once
+    let done = false;
+    const doCallback: RequestCallback = (...args) => {
+        if (done) return;
+        done = true;
+        callback(...args);
+    };
+
     const req = https.request(url, Object.assign({method: "GET"}, options), res => {
         if (redirectCodes.has(res.statusCode ?? 0) && res.headers.location) {
-            const final = new URL(res.headers.location);
+            if (redirectCount >= MAX_REDIRECTS) {
+                return doCallback(new Error(`Maximum amount of redirects reached (${MAX_REDIRECTS})`));
+            }
+
+            // Location headers may be relative to the requested url
+            const final = new URL(res.headers.location, url);
 
             for (const [key, value] of new URL(url).searchParams.entries()) {
                 final.searchParams.set(key, value);
             }
 
-            return makeRequest(final.toString(), options, callback, setReq);
+            // The recursive call owns the callback from here on
+            done = true;
+            return makeRequest(final.toString(), options, callback, setReq, redirectCount + 1);
         }
 
         const chunks: Buffer[] = [];
-        let error: Error | null = null;
 
         setReq(res, req);
 
-        res.addListener("error", err => {error = err;});
+        res.addListener("error", err => doCallback(err));
 
         res.addListener("data", chunk => {
             chunks.push(chunk);
         });
 
         res.addListener("end", () => {
+            if (done) return;
             const data = Object.fromEntries(dataToClone.map(h => [h, res[h]]));
 
-            callback(error as Error, data, Buffer.concat(chunks));
+            doCallback(null as unknown as Error, data, Buffer.concat(chunks));
             req.end();
         });
     });
@@ -50,7 +67,7 @@ const makeRequest = (url: string, options: RequestOptions, callback: RequestCall
         req.end();
     }
 
-    req.on("error", (error) => callback(error));
+    req.on("error", (error) => doCallback(error));
 };
 
 const request = function (url: string, options: RequestOptions, callback: RequestCallback) {

--- a/src/electron/preload/init.ts
+++ b/src/electron/preload/init.ts
@@ -14,15 +14,17 @@ export default function () {
         // Restore original preload for future windows
         IPC.send(IPCEvents.REGISTER_PRELOAD, preload);
         // Run original preload
+        const originalKill = process.kill;
         try {
-            const originalKill = process.kill;
             process.kill = function (_: number, __?: string | number | undefined) {return true;};
             // eslint-disable-next-line @typescript-eslint/no-require-imports
             require(preload);
-            process.kill = originalKill;
         }
         catch {
             // TODO bail out
+        }
+        finally {
+            process.kill = originalKill;
         }
     }
 }


### PR DESCRIPTION
# Pre-release bug audit

This PR is the output of a systematic bug audit of the whole codebase ahead of the next release. Every fix below was verified by reading the code (and callers) before changing anything, and the final diff was re-reviewed adversarially for regressions — that pass caught one issue in my own fix to `preload/api/https.ts`, which is folded in. `tsc`, eslint, all 253 tests, and the full build pass.

**Methodology:** five parallel reviewers swept the subsystems (electron main/preload + common, core modules/stores/structs, `BdApi` surface + polyfills, webpack tooling + utils, UI + builtins). Every reported finding was then manually verified against the source; anything that couldn't be confirmed as a real, user-visible defect was dropped. One finding was *refuted* during verification and deliberately **not** changed: the crash-disable flow in `main/modules/betterdiscord.ts` looks wrong at first glance (the `hasCrashed` flag is reset in `dom-ready` before injection), but `RUN_RENDERER` is invoked from the preload, which runs *before* `dom-ready` — so the injection guard actually sees the flag and correctly skips injection on the crash-reload.

The fixes are grouped by subsystem below, each with what was broken, how it manifests, and what the change does.

---

## Core patching (affects every plugin)

### `modules/patcher.ts` — double-unpatch removed *someone else's* patch
`unpatch()` did `patch.children.splice(patch.children.findIndex(...), 1)`. On a second invocation `findIndex` returns `-1`, and **`splice(-1, 1)` deletes the last element of the array** — i.e. another caller's active patch. Calling a returned unpatcher twice is a common defensive pattern (e.g. a plugin stores it *and* is swept by `unpatchAll`, which invokes the same closure). Result: plugin A double-unpatches, plugin B's hook on the same function silently stops firing; if it was the last child, the whole patch got reverted. Now the index is checked and a second call is a no-op.

### `api/patcher.ts` — `null` passed module validation
```js
typeof moduleToPatch !== "object" && typeof moduleToPatch !== "function" && moduleToPatch !== null
```
`typeof null === "object"`, so the first term is `false` and the whole `&&` chain is `false` for `null` — meaning `null` was considered *valid*. `Patcher.before("X", null, "fn", cb)` skipped the documented throw, flowed into `pushChildPatch`, and returned `null`; the plugin then stores `null` as its "unpatch function" and crashes at cleanup instead of getting the documented error at the call site. The intended logic is `(not object AND not function) OR null`; fixed accordingly. Affects all six Patcher/BoundPatcher entry points.

## Webpack module system

### `webpack/lazy.ts` — one bad search permanently wedged `getLazy` for the whole session
`queue._flushSync()` ran `getModule`/`getBulk` and only *afterwards* cleared `_queue` and reset `_scheduled`. If the search threw (reachable — see the `getBulk` fixes below), the microtask died with `_scheduled` still `true`: every pending `getLazy` promise never settled, and every **future** `getLazy`/`getLazyByKeys`/`getMangledLazy` from *any* plugin enqueued into a queue that would never flush again. Now wrapped in `try/catch/finally`: state always resets, and on error the queued entries are settled with `undefined` so callers fall through to the lazy-listener path instead of hanging (the error is rethrown for visibility, as before).

Two smaller fixes in the same file:
- `getLazy`'s success path (`cancel()`) never removed its `abort` listener — plugins reusing one long-lived `AbortController` for many lookups accumulated leaked closures for the controller's lifetime.
- `forceLoad` iterated module-level `/g` regexes (shared mutable `lastIndex`) across `await` points. Two concurrent `forceLoad` calls interleave `exec` on different strings through one `lastIndex` (skipped/mis-attributed chunk matches), and a rejected chunk load exited the loop leaving `lastIndex` dirty for the *next* call. The regexes are now instantiated per call from their `.source`.

### `webpack/utilities.ts` — `getBulk` fast paths crashed on stale cache / mishandled `all`
- The `firstId` and cached-id fast paths called `bulkGetMatched` on the raw module with no `shouldSkipModule` guard (the main scan has one). With `searchExports: true` and a stale `webpack.json` id now pointing at a null-exports module (typical after a Discord update), `Object.keys(module.exports)` threw — and via the lazy queue, that throw was the trigger for the session-wide `getLazy` wedge above.
- The `firstId` pass didn't skip `all: true` queries (the cache pass does): it stored a bare module where an array is expected, and the main scan's `returnedModules[index] ??= []` saw the existing non-array, so `.push` threw — or, if nothing else matched, an `all` caller received a single object instead of an array.

### `webpack/searching.ts` — `raw` ignored on one branch of `getMatched`
With `{raw: true, defaultExport: false, searchDefault: true}` and a match on the default export, `getMatched` returned `module.exports` while `bulkGetMatched` and `getLazy` return the raw module record for the same query. Same filter through `getModule` vs `getBulk` yielded different shapes. Reordered so `raw` wins, matching the other two implementations.

### `webpack/require.ts` — spurious unhandled rejections on failed chunk loads
`loadPromise.finally(onLoadEnd)` creates a *new* promise that re-rejects when a chunk fails to load, and nothing handled it — every failed `require.e` during startup emitted an `unhandledrejection` on top of Discord's own handling of the original promise. Changed to `loadPromise.then(onLoadEnd, onLoadEnd)`.

## `BdApi` surface

### `api/commands.ts` — the `Types` freeze froze nothing
`Types` is a class *field* (instance property), so `Object.freeze(CommandAPI.prototype.Types)` froze `undefined`, and `Object.freeze(CommandAPI.constructor)` froze `Function` itself. Any plugin could mutate `BdApi.Commands.Types.OptionTypes` etc. and corrupt the shared enums for every other plugin — exactly what the freeze was meant to prevent. Now the actual shared `Types` object is frozen, and `BoundCommandAPI` gets the same treatment as the other bound classes.

### `api/contextmenu.ts` — two fixes
- The injected Lucide-fill fix selector was missing the `.` before the danger class: `:where(.colorDefault_x, colorDanger_y)` — the second half is a *tag* selector that can never match, so the fill fix silently never applied to danger (red) menu items.
- `buildItem` did `props.label.replace(...)` unconditionally when deriving an id. `label` is optional for `control`-type items, so a legal `{type: "control", control: fn}` item threw a TypeError and took down the whole menu render. It now falls back to the item type.

### `api/ui.ts` — `showNotification` broke its documented contract when notifications are disabled
JSDoc says it returns an object with `isVisible`/`close`; with Settings → notifications off it returned `undefined`. This is the nasty class of bug that never reproduces on the developer's machine: `showNotification(...).close()` works fine in dev and crashes only for users with the setting off. It now returns an inert `{id, isVisible: () => false, close() {}}`.

## Node polyfills (legacy plugin compat)

### `polyfill/module.ts` — `require(<directory>)` could not work in any configuration
Three compounding bugs:
1. The index-file check was `ext.slice(0, -ext.length) == "index"` — slicing `.js` from index 0 to −3 always yields `""`, so it compared `"" == "index"`, always false. It meant to slice the **filename**.
2. `resolveMainFile` derived its scan directory from `basePath` (the *requiring* file's directory), not from the required target — so even the `package.json` branch read the wrong directory.
3. `_load` assigned the resolved main file to `mod` but then computed the loader from the *directory* path and called `loader(module, <directory>)` — so even if resolution had worked, the directory itself was "loaded".

Additionally, the require cache was **written under a different key than it was read**: reads used the realpath with extension appended, writes used the extensionless `mod`. Every extensionless `require("./util")` re-read and re-executed the module (broken module-level singletons, plus unbounded growth of never-hit cache entries). `_load` now resolves the main file against the target directory, loads that file, and caches consistently under the resolved path.

### `polyfill/https.ts` — `get` required the optional callback
`callback(emitter)` was invoked unconditionally, but Node's callback is optional — `require("https").get(url).on("error", ...)`, a very common legacy-plugin pattern, threw synchronously even though the function returns the emitter for exactly that usage.

### `polyfill/fs.ts` — callbacks could be invoked twice, with their own exception
`wrapFunctionWithCallback` called the user callback *inside* the `try`. If the callback itself threw (e.g. `fs.readFile(p, (err, data) => JSON.parse(data))` on malformed content), the `catch` invoked the callback a **second** time, presenting the callback's own exception as if the fs operation had failed. The success-path invocation is now outside the try (same fix applied to `writeFile`).

### `polyfill/index.ts` — `original-fs` wrappers mangled options and dropped callbacks
- `Object.assign({}, "utf8", {originalFs: true})` spreads the string into `{0:"u",1:"t",...}` — the Node-legal bare-encoding form lost its encoding entirely. Strings are now normalized to `{encoding}`.
- `originalFs.writeFile = (path, data, options) => ...` silently dropped the 4th (callback) argument — and when called in the 3-arg form, the callback landed in `options` and was discarded. Callers' callbacks never fired. The wrapper now handles both call forms.

## Managers / stores / misc renderer

### `modules/dommanager.ts` — CSS-escaped ids made styles unremovable
`escapeID` is `CSS.escape`. It was applied at **element creation** (so the DOM id attribute contained literal backslashes, e.g. `My\ Plugin`) *and* in the `querySelector` lookup — but the CSS parser un-escapes the selector back to `My Plugin`, which never matches the attribute `My\ Plugin`. For any id needing escaping — and `BdApi.DOM.addStyle` uses the *plugin name* as the id — every `addStyle` appended a fresh duplicate `<style>`, and `removeStyle` on plugin stop found nothing, so the CSS persisted after disable and stacked on every restart. Elements now carry the raw id; escaping happens only where a CSS selector is built. (`injectTheme`/`removeTheme` use literal `getElementById` and are consistent with raw ids.)

### `modules/addonmanager.ts` — "open in native editor" button did nothing
`editAddon`'s signature accepts `boolean` and the detached editor's popout-native button passes `true`, but no branch handled it — it fell through to `openDetached`, which immediately returned because that window was already open. `true` now maps to the system-editor path.

### `modules/updater.ts` — three fixes
- `getJSON` called `JSON.parse(body)` with no guard inside the request callback; a throw there means the wrapping promise **never settles**. Since `AddonUpdater.initialize()` `await`s it before registering its event listeners, one HTML error page from the API at startup killed addon-update detection for the whole session. Parse failures now resolve `[]` (same as the network-error path).
- `checkForUpdate` had no error handling around the GitHub calls: a fetch rejection or a rate-limit body without `tag_name` produced an unhandled rejection on every check interval. Now caught and logged (`checkForStable` also validates the response shape).
- `updateAddon` ignored the write callback's error: on a failed write (read-only folder, full disk) it showed the *success* toast and removed the update from pending while the old version was still on disk. It also passed `null` to `Logger.stacktrace` on non-200 responses. Both paths handled now.

### `stores/json.ts` — `recache` fired "changed" for every key, even on failure
The `finally` block diffed only **key sets**, so every key present before and after was reported as changed regardless of value — and on the `catch` path (`before === after`, the cache was never replaced) a *failed* recache still fired every listener with the old data. Plugins using `BdApi.Data` listeners re-rendered/re-applied settings spuriously. Now diffs values with `fast-equals`' `deepEqual` (already a dependency); a failed recache emits nothing.

### `secure.ts` — hardening patches crashed on legal inputs
- The `contentWindow` getter did `new Proxy(contentWindow, ...)` — for detached iframes the native getter returns `null`, and `new Proxy(null)` throws, so innocent `if (iframe.contentWindow)` checks crashed. Null is passed through now.
- The patched `XMLHttpRequest.open` called `url.toLowerCase()` — `xhr.open("GET", new URL(...))` is spec-legal (WebIDL stringifies) but exploded in the wrapper before the native call. Coerced with `String()`.

### `utils/icon.ts` — `size: "custom"` dropped its dimensions
`DiscordIconProps` documents `{size: "custom", width, height}`, but the Lucide wrapper passed only `size: sizes["custom"]` (= `undefined`) and never forwarded `width`/`height`, so custom-sized icons silently rendered at Lucide's 24px default.

### `common/events.ts` — error log printed the listener's source code
`Set.prototype.entries()` yields `[value, value]`; destructuring as `[index, listener]` made "index" the callback function itself, so the "at position ${index}" diagnostic dumped the function body. A real counter now.

### `common/utils/format.ts` — `$` patterns in values corrupted output
Values were passed as the raw `String.replace` replacement string, so `$&`, `$'`, `$1` in a value (user/plugin-supplied names reach this via i18n) were interpreted as replacement patterns. Now uses a replacer function, which is pattern-inert.

## UI & builtins

### `ui/updater.tsx` — updates panel showed stale state
- `updateAddon` mutated the state array in place and returned the same object from the `setUpdates` updater — React bails on `Object.is`-equal state, so the row for an updated addon never left the pending list.
- `checkAddons` spread the render-captured `updates` (`setUpdates({...updates, [type]: ...})`) and the panel fires plugin+theme checks concurrently — whichever finished last clobbered the other type's fresh results with the stale value. Both are functional updates now, and `checkAddons` no longer depends on `updates`.

### `ui/modals.ts` — fallback modal close ran 2–3×, corrupting the queue
In `Modals.default()` (used whenever Discord's `ModalActions` isn't found) every generated footer button's `onclick` already calls `handleClose()`, the auto-generated OK button's `action` *is* `handleClose`, and an extra listener was attached to the first footer button — so one click could run `handleClose` up to three times, each shifting `ModalQueue` and opening the next queued modal (two queued modals opening at once, or one silently consumed). Close is now guarded to run once.

Also: `showChangelogModal` did `Object.assign(options, props)`, mutating the caller-owned options object — including the shared imported changelog data — so modal-instance props (`transitionState`, `onClose`) persisted into subsequent opens. It copies now.

### `ui/notices.ts` — `onClose` fired twice
A notice with a `timeout` whose close button was clicked first still fired the timeout close later, running the caller's `onClose` a second time. `closeNotification` is now idempotent.

### `ui/tooltip.ts` — observer lifecycle and position classes
- The node-removal `MutationObserver` (body-wide, `subtree: true`) was never disconnected on `hide()` — it kept running for the page's lifetime per tooltip — and after it fired once, `show()`'s `if (this.observer) return` meant it was never *re*-connected, so a node that React re-mounted could once again produce the exact unclosable tooltip the observer was added to prevent. Now: reconnect on every `show()`, disconnect on `hide()`.
- `showAbove`/`showBelow`/`showLeft`/`showRight` added their class without removing the previous one, so a tooltip that flipped once carried e.g. both `bd-tooltip-top` and `bd-tooltip-bottom` forever, breaking the arrow styling. Side classes are exclusive now.

### `ui/settings/addonlist.tsx` — error boundaries keyed by list position
The `key` sat on the inner `AddonCard`, not the outermost mapped `<ErrorBoundary>`, so the list reconciled by index. If one addon's card crashed and the user re-sorted or searched, the error placeholder migrated to whatever *healthy* addon now occupied that position while the crashed one rendered normally. Key moved to the boundary.

### `ui/settings/components/color.tsx` — two fixes
- Number→hex conversion didn't zero-pad: `0x0000ff` became `"#ff"` — invalid for `<input type="color">` (rejected with a console warning) and invalid as a CSS background. Now padded to 6 digits.
- The swatch checkmark compared the resolved int against the *raw* `colors` entry, so plugins passing hex-string swatches (allowed by the type) never saw a selected checkmark. The entry is resolved before comparing.

### `ui/floating/window.tsx` — copy-paste bug in `maximize()`
The left-edge clamp branch set `style.height = (width - difference)` — wrong property *and* wrong pairing. Maximizing the floating editor on a small screen left the width unclamped (still overflowing) and corrupted the height with a width-derived value. Now sets `style.width`.

### `builtins/store/addonstore.ts` — three fixes
- Codeblock containment used `exec.index + exec.length` — `exec.length` is the number of regex capture groups (always 4 here), not the match length. Links overlapping codeblock boundaries were misclassified in both directions. Now `exec[0].length`.
- `patchLinkOpener` cached the **generator** returned by `getWithKey` (`this.linkOpener ??= getWithKey(...)`). Generators are one-shot: on re-enabling the builtin the exhausted generator destructured to `[undefined, undefined]`, `pushChildPatch` returned `null` silently, and the betterdiscord.app download-link interception stayed dead for the session with no error. The resolved `[module, key]` pair is cached instead.
- `extractDiscordProtocolList` monkey-patches `Array.prototype.includes` **globally** and only restored it from inside the interception branch. If `LinkParser.parse` threw, or Discord's parser changed such that the `"discord:"` check never ran, every array `includes` in the whole app ran through the shim forever. The restore now also happens in a `finally`.

### `builtins/customcss.ts` — deleting `custom.css` on disk didn't clear injected CSS
File deletion arrives as a `"rename"` event; the ENOENT branch recreated the file and reset internal state but never touched the DOM (the `insertCSS` call lives in the `"change"` branch, which a rename skips). The user's old CSS stayed injected until the next edit or restart. The deletion path now clears the injected CSS and emits `customcss-updated`.

## Electron main / preload

### `main/modules/betterdiscord.ts` — `disableMediaKeys` dropped existing `disable-features`
```js
`${originalDisable ? "," : ""}HardwareMediaKeyHandling,MediaSessionService`
```
When a `disable-features` value already existed, this prepended only a **comma** — not the original list. Enabling the media-keys setting silently re-enabled whatever features Discord/Chromium had disabled, and passed a malformed leading-comma value. The original list is now actually preserved.

### `main/modules/editor.ts` — canceled close orphaned the editor window
Cleanup was registered `once("close")`, but `close` fires (and `once` consumes the handler) even when the unsaved-changes handler cancels the close via `preventDefault()`. Picking "Cancel" left the window open but forgotten: opening the editor for the same file spawned a duplicate, and the orphan no longer auto-closed with the main window. Cleanup is now on `"closed"`, which only fires for real.

### `main/modules/reactdevtools.ts` — startup crash paths for users without Chrome
If the BD `extensions` fallback is absent and the platform Chrome directory doesn't exist, `readdirSync` threw — `findExtension` is called outside the try, and the `whenReady().then(async ...)` caller has no catch, so every launch with `reactDevTools` enabled and no Chrome installed produced an unhandled rejection in the main process. An empty version directory similarly fed `undefined` into `path.resolve`. Both guarded to return the intended "silently skip".

### `main/modules/ipc.ts` — hanging promises
- The `OPEN_WINDOW` handler's promise resolved only when the child window navigated to exactly `closeOnUrl` — if the user closed the window manually (or `closeOnUrl` was omitted), the renderer-side `invoke` hung forever. It now also resolves on `"closed"`.
- `inspectElement`'s `while (!isDevToolsOpened()) await 100ms` loop had no exit if devtools never open (blocked/destroyed webContents) — bounded now, and bails if the webContents is destroyed.
- "Unkown Mode" typo in the `OPEN_DIALOG` error.

### `preload/init.ts` — `process.kill` stub leaked on preload failure
The restore was inside the `try` with an empty catch: if Discord's original preload threw, `process.kill` stayed permanently stubbed to `() => true` in the preload context. Restored in a `finally`.

### `preload/api/https.ts` — four fixes in the legacy request backend
- `new URL(res.headers.location)` had no base, so an RFC-legal **relative** redirect (`Location: /path` — very common) threw `Invalid URL` synchronously inside the response callback: uncaught exception, caller's callback never invoked. Now resolved against the request url.
- Redirects recursed with no cap — a redirect loop (A→B→A) re-requested forever. Capped at 20 (matching the fetch backend).
- A response-stream error was only stashed and delivered via the `"end"` listener — but a stream that errors doesn't emit `"end"`, so on mid-transfer failure the callback silently never fired and the request appeared to hang.
- The adversarial review of this very fix then caught that the *request*-level error listener wasn't covered by the new once-guard: in Node's http client a mid-response socket death surfaces on **both** the request and response objects, which would have invoked the callback twice (duplicate error toasts, plugin error handlers running twice). There's now a single once-guard covering every path, with the guard handed off to the recursive call on redirect.

### `preload/api/fetch.ts` — same relative-`Location` bug as above
`BdApi.Net.fetch` rejected with `Invalid URL` on any valid relative redirect. Resolved against the current uri.

---

## Verified findings deliberately *not* fixed (for triage)

These are real but are behavioral/API decisions or need design input, so they're reported rather than patched:

- **`webpack/require.ts` pre-runtime injection**: the `window.webpackChunkdiscord_app ??= []` fallback implies BD may run before Discord's webpack runtime, but if that ever happens, the top-level `getModule` fallback dereferences `webpackRequire.c` while it's still `undefined` (startup crash), and the runtime would capture BD's `handlePush` as its parent chunk-loading function → mutual recursion on the first chunk push. Fine if injection timing is guaranteed post-runtime; worth a guard if not.
- **`secure.ts` proxy identity**: every `contentWindow` read constructs a *new* Proxy, so `iframe.contentWindow === iframe.contentWindow` is `false`, and `event.source === iframe.contentWindow` checks in postMessage handlers always fail. Fixing needs a WeakMap proxy cache keyed on the underlying WindowProxy.
- **`addonmanager.readAddon` duplicate `@name`s**: the pre-overhaul code threw an `alreadyExists` AddonError for a second file with the same `@name`; the rewrite pushes unconditionally, so two files share one id and one enable-state entry, and toggle/resolve operations act on the first while the second may keep running.
- **303 redirects**: neither preload backend follows `303 See Other`, and 301/302 re-send the original method/body (browsers switch to GET). Following 303 correctly requires the method/body switch, so it's a deliberate-behavior question.
- **Polyfill contract deviations plugins may have adapted to**: `require.resolve` returns a cached module object instead of a path string (and matches by loose `startsWith`); `fs.exists`'s callback is err-first instead of Node's `(exists)`. Fixing either changes observable behavior for existing plugins.
- **`Net.fetch` method whitelist**: non-whitelisted methods (e.g. `PROPFIND`) are silently rewritten to `GET`; throwing would give plugin devs a real error instead of a wrong-verb "success".
- **Side effects during React render**: `builtins/developer/recovery.tsx` disables addons/writes to disk/shows notifications *during* the error-boundary render; `ui/settings.tsx`'s panel-title context does setState-during-render of another component (and throws if the header hasn't rendered yet).
- **Lazy-patch races in builtins**: patch methods `await` webpack lookups before `this.after(...)`, but `disabled()` runs `unpatchAll()` synchronously — toggling a builtin off quickly can apply a patch *after* its unpatch swept, leaving it active while shown disabled.
- Smaller items: `Spinner` lets a caller `className` *replace* its own classes (spread order); radio settings never re-derive selection from external store changes; the Monaco fallback `<textarea>` path lacks effect cleanup and can duplicate editors; BD's own polyfills (`crypto.randomBytes`, request/https body conversion) trip the `window.Buffer` deprecation warning they're meant to aim at plugins; the renderer subscribes to `MINIMIZE`/`MAXIMIZE` IPC events nothing ever sends; `reactdevtools.remove()` passes a filesystem path where `removeExtension` wants an extension id (currently dead code); `findLatestVersion` picks the lexicographically-last version directory, not the highest version.

## Validation

- `bun run typecheck` (tsc) — clean
- `bun run lint` (eslint) — clean
- `bun test tests/` — 253 pass, 0 fail
- `bun run build` — all seven modules build

Happy to split any of this into separate PRs, revert anything you'd rather handle differently, or take a crack at the report-only items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uoyY6YC5vdTYYLM8EWtVe

---
_Generated by [Claude Code](https://claude.ai/code/session_013uoyY6YC5vdTYYLM8EWtVe)_