### PR TITLE
enable publishing for bdapi types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Bun
         uses: oven-sh/setup-bun@v2
@@ -39,16 +39,17 @@ jobs:
 
       # Only upload artifact on PR, otherwise it gets pushed to canary
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{github.event_name == 'pull_request'}}
         with:
           if-no-files-found: error
           retention-days: 30
+          archive: false
           path: dist/betterdiscord.asar
 
       # Update the canary tag on push to development
       - name: Update tag
-        uses: richardsimko/update-tag@v1
+        uses: richardsimko/update-tag@v2
         if: ${{github.event_name == 'push'}}
         with:
           tag_name: canary
@@ -57,7 +58,7 @@ jobs:
 
       # Update the canary release on push to development
       - name: Update canary release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{github.event_name == 'push'}}
         with:
           prerelease: true

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -7,6 +7,10 @@ on:
       - "@betterdiscord/types@*"
   # Allow manual publishing from the Actions tab.
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3)"
+        required: true
 
 jobs:
   publish:
@@ -36,6 +40,19 @@ jobs:
 
       - name: Generate types
         run: bun run generate-types
+
+      # The committed types/package.json version is a 0.0.0 placeholder;
+      # the published version comes from the tag or the manual run input.
+      - name: Set package version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            version="$INPUT_VERSION"
+          else
+            version="${GITHUB_REF_NAME#@betterdiscord/types@}"
+          fi
+          npm pkg set version="$version" --prefix ./dist/types
 
       - name: Publish to npm
         run: npm publish ./dist/types --provenance --access public

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -30,9 +30,9 @@ jobs:
           bun-version: latest
 
       - name: Prepare Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6 # v7 is available but just released yesterday and may have issues with the npm registry
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -1,0 +1,41 @@
+name: Publish Types
+
+on:
+  # Publish when a types release is created (tag prefixed with "@betterdiscord/types@", e.g. @betterdiscord/types@1.0.0).
+  push:
+    tags:
+      - "@betterdiscord/types@*"
+  # Allow manual publishing from the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Prepare Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate types
+        run: bun run generate-types
+
+      - name: Publish to npm
+        run: npm publish ./dist/types --provenance --access public

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "translations": "bun -r dotenv/config scripts/translations.js",
         "circulars": "bun run --bun dpdm -T --no-warning --no-tree src/betterdiscord/index.js",
         "typecheck": "tsc",
-        "generate-types": "bun scripts/types"
+        "generate-types": "bun scripts/types",
+        "publish-types": "bun run generate-types && npm publish ./dist/types"
     },
     "devDependencies": {
         "@electron/asar": "^3.2.0",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -31,6 +31,7 @@ async function buildTypes() {
         })]
     });
 
+    await rm(outDir, {recursive: true, force: true});
     await mkdir(outDir, {recursive: true});
     await bundle.write({
         file: `${outDir}/index.d.ts`,

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -2,8 +2,15 @@ import tsconfig from "../tsconfig.json";
 import {$} from "bun";
 import {rollup} from "rollup";
 import {dts} from "rollup-plugin-dts";
-import {readFile, writeFile} from "node:fs/promises";
+import {readFile, writeFile, mkdir, copyFile, rm} from "node:fs/promises";
 import {ModuleResolutionKind} from "typescript";
+
+// Intermediate per-file declarations emitted by tsc (see declaration.tsconfig.json).
+const declarationsDir = "./dist/declarations";
+// Final publishable package directory (@betterdiscord/types).
+const outDir = "./dist/types";
+// Committed sources copied verbatim into the published package.
+const packageDir = "./types";
 
 await buildTypes();
 
@@ -11,12 +18,12 @@ async function buildTypes() {
     console.log("Generating declaration files...");
     await $`tsc -p ./declaration.tsconfig.json`;
 
-    console.log("Bundling into bdapi.d.ts...");
+    console.log("Bundling into index.d.ts...");
     const bundle = await rollup({
-        input: "./dist/declarations/src/betterdiscord/api/index.d.ts",
+        input: `${declarationsDir}/src/betterdiscord/api/index.d.ts`,
         plugins: [dts({
             compilerOptions: {
-                baseUrl: "./dist/declarations",
+                baseUrl: declarationsDir,
                 moduleResolution: ModuleResolutionKind.Bundler,
                 paths: tsconfig.compilerOptions.paths
             },
@@ -24,15 +31,16 @@ async function buildTypes() {
         })]
     });
 
+    await mkdir(outDir, {recursive: true});
     await bundle.write({
-        file: "./dist/bdapi.d.ts",
+        file: `${outDir}/index.d.ts`,
         format: "es"
     });
 
     await bundle.close();
 
-    console.log("Finalizing bdapi.d.ts...");
-    let content = await readFile("./dist/bdapi.d.ts", "utf-8");
+    console.log("Finalizing index.d.ts...");
+    let content = await readFile(`${outDir}/index.d.ts`, "utf-8");
 
     // Remove declarations and put everything in a namespace
     content = content.replaceAll("\r\n", "\n")
@@ -48,6 +56,15 @@ async function buildTypes() {
 
     content = header + content.slice(0, insertAt) + namespaces + content.slice(insertAt + 1) + "\n}" + declaration + "\n}";
 
-    await writeFile("./dist/bdapi.d.ts", content, "utf-8");
-    console.log("Done!");
+    await writeFile(`${outDir}/index.d.ts`, content, "utf-8");
+
+    console.log("Assembling package...");
+    await copyFile(`${packageDir}/package.json`, `${outDir}/package.json`);
+    await copyFile(`${packageDir}/README.md`, `${outDir}/README.md`);
+    await copyFile("./LICENSE", `${outDir}/LICENSE`);
+
+    // The intermediate per-file declarations are no longer needed.
+    await rm(declarationsDir, {recursive: true, force: true});
+
+    console.log(`Done! Package ready in ${outDir}`);
 }

--- a/src/betterdiscord/modules/emitter.ts
+++ b/src/betterdiscord/modules/emitter.ts
@@ -1,6 +1,6 @@
 import EventEmitter from "events";
 
-export default new class BDEvents extends EventEmitter {
+class BDEvents extends EventEmitter {
     constructor() {
         super();
         this.setMaxListeners(20);
@@ -9,4 +9,6 @@ export default new class BDEvents extends EventEmitter {
     dispatch(eventName: string, ...args: any[]) {
         this.emit(eventName, ...args);
     }
-};
+}
+
+export default new BDEvents();

--- a/src/betterdiscord/modules/pluginmanager.ts
+++ b/src/betterdiscord/modules/pluginmanager.ts
@@ -28,7 +28,7 @@ if (module.exports.default) {
     module.exports = module.exports.default;
 }`;
 
-export default new class PluginManager extends AddonManager<Plugin> {
+class PluginManager extends AddonManager<Plugin> {
     name = "PluginManager";
     extension = ".plugin.js";
     duplicatePattern = /\.plugin\s?\([0-9]+\)\.js/;
@@ -254,4 +254,6 @@ export default new class PluginManager extends AddonManager<Plugin> {
             catch (err) {Logger.stacktrace(this.name, `Unable to fire observer for ${this.addonList[i].name} v${this.addonList[i].version}`, err as Error);}
         }
     }
-};
+}
+
+export default new PluginManager();

--- a/src/betterdiscord/modules/thememanager.ts
+++ b/src/betterdiscord/modules/thememanager.ts
@@ -29,7 +29,7 @@ function parseProperty(raw: string) {
     return out;
 }
 
-export default new class ThemeManager extends AddonManager<Theme> {
+class ThemeManager extends AddonManager<Theme> {
     name = "ThemeManager";
     extension = ".theme.css";
     duplicatePattern = /\.theme\s?\([0-9]+\)\.css/;
@@ -92,4 +92,6 @@ export default new class ThemeManager extends AddonManager<Theme> {
         }
         return out;
     }
-};
+}
+
+export default new ThemeManager();

--- a/src/betterdiscord/stores/addonerrors.ts
+++ b/src/betterdiscord/stores/addonerrors.ts
@@ -1,7 +1,7 @@
 import type AddonError from "@structs/addonerror";
 import Store from "./base";
 
-export default new class AddonErrorsStore extends Store {
+class AddonErrorsStore extends Store {
     pluginErrors: AddonError[] = [];
     themeErrors: AddonError[] = [];
 
@@ -20,4 +20,6 @@ export default new class AddonErrorsStore extends Store {
         this.themeErrors = [];
         this.emitChange();
     }
-};
+}
+
+export default new AddonErrorsStore();

--- a/src/betterdiscord/stores/config.ts
+++ b/src/betterdiscord/stores/config.ts
@@ -2,7 +2,7 @@ import path from "path";
 import Store from "./base";
 
 
-export default new class ConfigStore extends Store {
+class ConfigStore extends Store {
     data = {
         branch: process.env.__BRANCH__!,
         commit: process.env.__COMMIT__!,
@@ -30,4 +30,6 @@ export default new class ConfigStore extends Store {
 
     get isDevelopment() {return this.data.build !== "production";}
     get isCanary() {return this.data.branch !== "main";}
-};
+}
+
+export default new ConfigStore();

--- a/src/betterdiscord/stores/editor.ts
+++ b/src/betterdiscord/stores/editor.ts
@@ -5,7 +5,7 @@ import RemoteAPI from "@polyfill/remote";
 
 const EDITOR_URL_REGEX = /^betterdiscord:\/\/editor\/(?:custom-css|(theme|plugin)\/([^/]+))\/?/;
 
-export default new class EditorStore extends Store {
+class EditorStore extends Store {
     constructor() {
         super();
 
@@ -78,4 +78,6 @@ export default new class EditorStore extends Store {
             renderWhitespace: SettingsManager.get("settings", "editor", "renderWhitespace")
         };
     }
-};
+}
+
+export default new EditorStore();

--- a/src/betterdiscord/stores/settings.ts
+++ b/src/betterdiscord/stores/settings.ts
@@ -35,7 +35,7 @@ export interface SettingsPanel {
 
 type State = Record<string, Record<string, any>>;
 
-export default new class SettingsManager extends Store {
+class SettingsManager extends Store {
     state: State = {};
     collections: SettingsCollection[] = [];
     panels: SettingsPanel[] = [];
@@ -284,4 +284,6 @@ export default new class SettingsManager extends Store {
         Events.on("setting-updated", handler);
         return () => {Events.off("setting-updated", handler);};
     }
-};
+}
+
+export default new SettingsManager();

--- a/types/README.md
+++ b/types/README.md
@@ -11,7 +11,7 @@ the `window.BdApi` augmentation, and the `BetterDiscord` namespace available to 
 npm install --save-dev @betterdiscord/types
 ```
 
-The package declares peer type packages (`@types/react`, `@types/react-dom`,
+The package declares related type packages (`@types/react`, `@types/react-dom`,
 `@types/react-reconciler`) as dependencies, so they will be installed alongside it.
 
 ## Usage

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,49 @@
+# @betterdiscord/types
+
+TypeScript type definitions for the [BetterDiscord](https://betterdiscord.app) plugin API (`BdApi`).
+
+These types are generated from the BetterDiscord source and describe the global `BdApi` object,
+the `window.BdApi` augmentation, and the `BetterDiscord` namespace available to plugins.
+
+## Installation
+
+```sh
+npm install --save-dev @betterdiscord/types
+```
+
+The package declares peer type packages (`@types/react`, `@types/react-dom`,
+`@types/react-reconciler`) as dependencies, so they will be installed alongside it.
+
+## Usage
+
+Add the types to your `tsconfig.json` so they are picked up globally:
+
+```jsonc
+{
+    "compilerOptions": {
+        "types": ["@betterdiscord/types"]
+    }
+}
+```
+
+Or reference them directly from a source file:
+
+```ts
+/// <reference types="@betterdiscord/types" />
+```
+
+Once referenced, `BdApi` and the `BetterDiscord` namespace are available globally with full
+type information:
+
+```ts
+const { Webpack, Patcher } = new BdApi("MyPlugin");
+```
+
+## Versioning
+
+This package is versioned independently of BetterDiscord itself. Type changes follow semver
+based on the shape of the API surface, not the BetterDiscord release version.
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@betterdiscord/types",
+    "version": "1.0.0",
+    "description": "TypeScript type definitions for the BetterDiscord plugin API (BdApi).",
+    "types": "index.d.ts",
+    "files": [
+        "index.d.ts",
+        "README.md",
+        "LICENSE"
+    ],
+    "keywords": [
+        "betterdiscord",
+        "bdapi",
+        "discord",
+        "types",
+        "typescript"
+    ],
+    "license": "Apache-2.0",
+    "homepage": "https://betterdiscord.app",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/BetterDiscord/BetterDiscord.git",
+        "directory": "types"
+    },
+    "bugs": {
+        "url": "https://github.com/BetterDiscord/BetterDiscord/issues"
+    },
+    "dependencies": {
+        "@types/react": "^19.1.2",
+        "@types/react-dom": "^19.1.2",
+        "@types/react-reconciler": "^0.32.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@betterdiscord/types",
-    "version": "1.0.0",
+    "version": "0.0.0",
     "description": "TypeScript type definitions for the BetterDiscord plugin API (BdApi).",
     "types": "index.d.ts",
     "files": [


### PR DESCRIPTION
Also allows auto publish whenever a git tag like `@betterdiscord/types@1.0.0` gets pushed. Also opted to swap bdapi.d.ts for index.d.ts since that's "industry standard"

cc: @TheLazySquid 