### PR TITLE
Enhanced os accent color

### DIFF
--- a/src/betterdiscord/modules/core.ts
+++ b/src/betterdiscord/modules/core.ts
@@ -15,7 +15,6 @@ import Settings from "@stores/settings";
 import JsonStore from "@stores/json";
 import DiscordModules from "./discordmodules";
 
-import IPC from "./ipc";
 import Updater from "./updater";
 import AddonStore from "./addonstore";
 
@@ -39,8 +38,6 @@ export default new class Core {
     async startup() {
         if (this.hasStarted) return;
         this.hasStarted = true;
-
-        IPC.getSystemAccentColor().then(value => DOMManager.injectStyle("bd-os-values", `:root {--os-accent-color: #${value};}`));
 
         this.trustBetterDiscordProtocol();
 

--- a/src/betterdiscord/modules/ipc.ts
+++ b/src/betterdiscord/modules/ipc.ts
@@ -58,10 +58,6 @@ export default new class IPCRenderer {
         return ipc.invoke(IPCEvents.OPEN_DIALOG, options);
     }
 
-    getSystemAccentColor(): Promise<string> {
-        return ipc.invoke(IPCEvents.GET_ACCENT_COLOR);
-    }
-
     openPath(path: string) {
         return ipc.send(IPCEvents.OPEN_PATH, path);
     }

--- a/src/common/constants/ipcevents.ts
+++ b/src/common/constants/ipcevents.ts
@@ -17,7 +17,6 @@ export const WINDOW_SIZE                = "bd-window-size";
 export const DEVTOOLS_WARNING           = "bd-remove-devtools-message";
 export const OPEN_DIALOG                = "bd-open-dialog";
 export const REGISTER_PRELOAD           = "bd-register-preload";
-export const GET_ACCENT_COLOR           = "bd-get-accent-color";
 export const OPEN_PATH                  = "bd-open-path";
 export const HANDLE_PROTOCOL            = "bd-handle-protocol";
 export const EDITOR_OPEN                = "bd-editor-open";

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import electron, {BrowserWindow} from "electron";
+import electron, {BrowserWindow, systemPreferences} from "electron";
 import {spawn} from "child_process";
 
 import ReactDevTools from "./reactdevtools";
@@ -120,8 +120,22 @@ export default class BetterDiscord {
         if (!success) return; // TODO: cut a fatal log
     }
 
-    static setup(browserWindow: BrowserWindow) {
+    private static getAccentColor() {
+        if (process.env.BD_ACCENT_COLOR) return process.env.BD_ACCENT_COLOR;
 
+        try {
+            const hex = systemPreferences.getAccentColor();
+
+            // Docs state this doesnt return with # but it does (for me?)
+            if (hex[0] === "#") return hex;
+            return `#${hex}`;
+        }
+        catch {
+            return "#3E82E5";
+        }
+    }
+
+    static setup(browserWindow: BrowserWindow) {
         // Setup some useful vars to avoid blocking IPC calls
         try {
             // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -137,10 +151,30 @@ export default class BetterDiscord {
         process.env.DISCORD_USER_DATA = electron.app.getPath("userData");
         process.env.BETTERDISCORD_DATA_PATH = bdFolder;
 
+        let promise: Promise<string>;
+        let isAwaiting = false;
+
+        const onChange = async () => {
+            if (isAwaiting) return;
+
+            isAwaiting = true;
+
+            await browserWindow.webContents.removeInsertedCSS(await promise);
+
+            isAwaiting = false;
+
+            promise = browserWindow.webContents.insertCSS(`:root { --os-accent-color: ${this.getAccentColor()}; }`);
+        };
+
+        systemPreferences.on("accent-color-changed", onChange);
+        browserWindow.once("closed", () => systemPreferences.off("accent-color-changed", onChange));
+
         // When DOM is available, pass the renderer over the wall
         browserWindow.webContents.on("dom-ready", () => {
-            // Temporary fix for new canary/ptb changes
-            if (!hasCrashed) return;
+            if (!hasCrashed) {
+                promise = browserWindow.webContents.insertCSS(`:root { --os-accent-color: ${this.getAccentColor()}; }`);
+                return;
+            }
 
             // If a previous crash was detected, show a message explaining why BD isn't there
             electron.dialog.showMessageBox({

--- a/src/electron/main/modules/betterdiscord.ts
+++ b/src/electron/main/modules/betterdiscord.ts
@@ -16,6 +16,8 @@ if (process.platform === "win32" || process.platform === "darwin") bdFolder = pa
 else bdFolder = process.env.XDG_CONFIG_HOME ? process.env.XDG_CONFIG_HOME : path.join(process.env.HOME!, ".config"); // This will help with snap packages eventually
 bdFolder = path.join(bdFolder, "BetterDiscord") + "/";
 
+const BD_ACCENT_COLOR = "#3E82E5";
+
 let hasCrashed = false;
 export default class BetterDiscord {
     static _settings: Record<string, Record<string, any>>;
@@ -125,13 +127,14 @@ export default class BetterDiscord {
 
         try {
             const hex = systemPreferences.getAccentColor();
+            if (!hex) return BD_ACCENT_COLOR;
 
             // Docs state this doesnt return with # but it does (for me?)
             if (hex[0] === "#") return hex;
             return `#${hex}`;
         }
         catch {
-            return "#3E82E5";
+            return BD_ACCENT_COLOR;
         }
     }
 

--- a/src/electron/main/modules/ipc.ts
+++ b/src/electron/main/modules/ipc.ts
@@ -1,5 +1,5 @@
 import {spawn} from "child_process";
-import {ipcMain as ipc, BrowserWindow, app, dialog, systemPreferences, shell, type IpcMainInvokeEvent, type IpcMainEvent, type BrowserWindowConstructorOptions} from "electron";
+import {ipcMain as ipc, BrowserWindow, app, dialog, shell, type IpcMainInvokeEvent, type IpcMainEvent, type BrowserWindowConstructorOptions} from "electron";
 
 import * as IPCEvents from "@common/constants/ipcevents";
 import Editor from "./editor";
@@ -128,12 +128,6 @@ const setWindowSize = (event: IpcMainEvent, width: number, height: number) => {
     window?.setSize(width, height);
 };
 
-const getAccentColor = () => {
-    // intentionally left blank so that fallback colors will be used
-    return ((process.platform == "win32" || process.platform == "darwin")
-        && systemPreferences.getAccentColor()) || "";
-};
-
 const stopDevtoolsWarning = (event: IpcMainEvent) => event.sender.removeAllListeners("devtools-opened");
 
 
@@ -220,7 +214,6 @@ export default class IPCMain {
             ipc.on(IPCEvents.DEVTOOLS_WARNING, stopDevtoolsWarning);
             ipc.on(IPCEvents.REGISTER_PRELOAD, registerPreload);
             ipc.on(IPCEvents.EDITOR_SETTINGS_GET, getSettings);
-            ipc.handle(IPCEvents.GET_ACCENT_COLOR, getAccentColor);
             ipc.handle(IPCEvents.RUN_SCRIPT, runScript);
             ipc.handle(IPCEvents.OPEN_DIALOG, openDialog);
             ipc.handle(IPCEvents.OPEN_WINDOW, createBrowserWindow);


### PR DESCRIPTION
Now supports linux and will update when the accent color changed w/o needing to reload.

Additionally adds `process.env.BD_ACCENT_COLOR` to provide a custom accent color (mainly for pre macOS 1.14)