### PR TITLE
Fix canary release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,6 @@ jobs:
           body: This is the canary release for BetterDiscord automatically kept up to date using GitHub actions.
           tag_name: canary
           fail_on_unmatched_files: true
-          path: |
+          files: |
             dist/betterdiscord.asar
             dist/checksums.txt


### PR DESCRIPTION
softprops/action-gh-release@v3 uses files not path unlike actions/upload-artifact@v7